### PR TITLE
Custom Options in single select: event

### DIFF
--- a/public/custom-options.html
+++ b/public/custom-options.html
@@ -22,12 +22,35 @@
 </nav>
 
 <div class="container">
-  <div>
+  <div id="empty-single-select-value-changed-example">
     <h3>Add Custom Options</h3>
     <p>
       Using the <code>allow-custom-options</code> attribute to allow the user to choose a their own value (one that is not in the list of options).
     </p>
     <much-select allow-custom-options="true"></much-select>
+    <p>
+      Events:
+    <table id="single-select-custom-option-event-log">
+      <thead>
+      <tr>
+        <th>Event</th>
+        <th>Details</th>
+      </tr>
+      </thead>
+      <tbody>
+      </tbody>
+    </table>
+    </p>
+    <script>
+      window.addEventListener("load", () => {
+        document
+          .querySelector("#empty-single-select-value-changed-example much-select")
+          .addEventListener(
+            "customValueSelected",
+            makeLogEventHandler("single-select-custom-option-event-log")
+          );
+      });
+    </script>
   </div>
 </div>
 

--- a/public/custom-options.html
+++ b/public/custom-options.html
@@ -25,7 +25,7 @@
   <div>
     <h3>Add Custom Options</h3>
     <p>
-      Using the `allow-custom-options` attribute to allow the user to choose a their own value (one that is not in the list of options).
+      Using the <code>allow-custom-options</code> attribute to allow the user to choose a their own value (one that is not in the list of options).
     </p>
     <much-select allow-custom-options="true"></much-select>
   </div>

--- a/public/custom-options.html
+++ b/public/custom-options.html
@@ -28,8 +28,7 @@
       Using the <code>allow-custom-options</code> attribute to allow the user to choose a their own value (one that is not in the list of options).
     </p>
     <much-select allow-custom-options="true"></much-select>
-    <p>
-      Events:
+    <p>Events:</p>
     <table id="single-select-custom-option-event-log">
       <thead>
       <tr>
@@ -40,7 +39,6 @@
       <tbody>
       </tbody>
     </table>
-    </p>
     <script>
       window.addEventListener("load", () => {
         document
@@ -48,6 +46,42 @@
           .addEventListener(
             "customValueSelected",
             makeLogEventHandler("single-select-custom-option-event-log")
+          );
+      });
+    </script>
+  </div>
+
+  <div id="not-empty-single-select-value-changed-example">
+    <h3>Add Custom Options (or select from the existing options)</h3>
+    <p>
+      If we type in an option that matches an existing option is should <em>not</em>
+      show the option to add a custom option.
+    </p>
+    <much-select allow-custom-options="true">
+      <select>
+        <option>Flashlight</option>
+        <option>Lantern</option>
+        <option>Candle</option>
+      </select>
+    </much-select>
+    <p>Events:</p>
+    <table id="not-empty-single-select-custom-option-event-log">
+      <thead>
+      <tr>
+        <th>Event</th>
+        <th>Details</th>
+      </tr>
+      </thead>
+      <tbody>
+      </tbody>
+    </table>
+    <script>
+      window.addEventListener("load", () => {
+        document
+          .querySelector("#not-empty-single-select-value-changed-example much-select")
+          .addEventListener(
+            "customValueSelected",
+            makeLogEventHandler("not-empty-single-select-custom-option-event-log")
           );
       });
     </script>

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,7 +1,21 @@
 module Main exposing (..)
 
 import Browser
-import Css exposing (block, display, fontSize, hidden, inline, lineHeight, none, px, top, visibility, visible, width)
+import Css
+    exposing
+        ( block
+        , display
+        , fontSize
+        , hidden
+        , inline
+        , lineHeight
+        , none
+        , px
+        , top
+        , visibility
+        , visible
+        , width
+        )
 import Html.Styled
     exposing
         ( Html
@@ -25,7 +39,16 @@ import Html.Styled.Attributes
         , type_
         , value
         )
-import Html.Styled.Events exposing (onBlur, onClick, onFocus, onInput, onMouseDown, onMouseEnter, onMouseLeave)
+import Html.Styled.Events
+    exposing
+        ( onBlur
+        , onClick
+        , onFocus
+        , onInput
+        , onMouseDown
+        , onMouseEnter
+        , onMouseLeave
+        )
 import Json.Decode
 import Keyboard exposing (Key(..))
 import Keyboard.Events as Keyboard
@@ -50,6 +73,7 @@ import OptionSearcher exposing (bestMatch)
 import Ports
     exposing
         ( addOptionsReceiver
+        , allowCustomOptionsReceiver
         , blurInput
         , deselectOptionReceiver
         , disableChangedReceiver
@@ -88,6 +112,7 @@ type Msg
     | PlaceholderAttributeChanged String
     | LoadingAttributeChanged Bool
     | MaxDropdownItemsChanged Int
+    | AllowCustomOptionsChanged Bool
     | DisabledAttributeChanged Bool
     | SelectHighlightedOption
     | DeleteInputForSingleSelect
@@ -294,6 +319,11 @@ update msg model =
 
         MaxDropdownItemsChanged int ->
             ( { model | maxDropdownItems = int }, Cmd.none )
+
+        AllowCustomOptionsChanged canAddCustomOptions ->
+            ( { model | selectionMode = SelectionMode.setAllowCustomOptionsWithBool canAddCustomOptions model.selectionMode }
+            , Cmd.none
+            )
 
         DisabledAttributeChanged bool ->
             ( { model | disabled = bool }, Cmd.none )
@@ -1005,6 +1035,7 @@ subscriptions _ =
         , disableChangedReceiver DisabledAttributeChanged
         , optionsChangedReceiver OptionsChanged
         , maxDropdownItemsChangedReceiver MaxDropdownItemsChanged
+        , allowCustomOptionsReceiver AllowCustomOptionsChanged
         , valueCasingDimensionsChangedReceiver ValueCasingWidthUpdate
         , selectOptionReceiver SelectOption
         , deselectOptionReceiver DeselectOption

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -75,7 +75,7 @@ import Ports
         ( addOptionsReceiver
         , allowCustomOptionsReceiver
         , blurInput
-        , customOptionCreated
+        , customOptionSelected
         , deselectOptionReceiver
         , disableChangedReceiver
         , errorMessage
@@ -940,7 +940,7 @@ makeCommandMessagesWhenValuesChanges options =
                 Cmd.none
 
             else
-                customOptionCreated (Option.optionsValues selectedCustomOptions)
+                customOptionSelected (Option.optionsValues selectedCustomOptions)
     in
     Cmd.batch [ valueChanged (selectedOptionsToTuple options), customOptionCmd ]
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -198,18 +198,27 @@ update msg model =
             ( { model | options = options }, Cmd.batch [ valueChanged (selectedOptionsToTuple options), blurInput () ] )
 
         SearchInputOnInput string ->
+            let
+                options =
+                    case SelectionMode.getCustomOptions model.selectionMode of
+                        AllowCustomOptions ->
+                            Option.updateOrAddCustomOption string model.options
+
+                        NoCustomOptions ->
+                            model.options
+            in
             case bestMatch string model.options of
                 Just (Option _ _ value _ _) ->
-                    ( { model | searchString = string, options = highlightOptionInListByValue value model.options }, Cmd.none )
+                    ( { model | searchString = string, options = highlightOptionInListByValue value options }, Cmd.none )
 
-                Just (CustomOption _ _ _) ->
-                    ( { model | searchString = string }, Cmd.none )
+                Just (CustomOption _ _ value) ->
+                    ( { model | searchString = string, options = highlightOptionInListByValue value options }, Cmd.none )
 
                 Just (EmptyOption _ _) ->
-                    ( { model | searchString = string }, Cmd.none )
+                    ( { model | searchString = string, options = options }, Cmd.none )
 
                 Nothing ->
-                    ( { model | searchString = string }, Cmd.none )
+                    ( { model | searchString = string, options = options }, Cmd.none )
 
         ValueChanged valuesJson ->
             let

--- a/src/Option.elm
+++ b/src/Option.elm
@@ -7,6 +7,7 @@ module Option exposing
     , OptionValue
     , addAdditionalOptionsToOptionList
     , addAndSelectOptionsInOptionsListByString
+    , customSelectedOptions
     , decoder
     , deselectAllOptionsInOptionsList
     , deselectAllSelectedHighlightedOptions
@@ -35,6 +36,7 @@ module Option exposing
     , optionLabelToSearchString
     , optionLabelToString
     , optionsDecoder
+    , optionsValues
     , removeHighlightOptionInList
     , removeOptionsFromOptionList
     , selectHighlightedOption
@@ -325,6 +327,11 @@ getOptionDescription option =
 selectedOptionsToTuple : List Option -> List ( String, String )
 selectedOptionsToTuple options =
     options |> selectedOptions |> List.map optionToValueLabelTuple
+
+
+optionsValues : List Option -> List String
+optionsValues options =
+    List.map getOptionValueAsString options
 
 
 selectOptionsInOptionsListByString : List String -> List Option -> List Option
@@ -620,7 +627,7 @@ selectSingleOptionInList value options =
                         CustomOption _ _ optionValue ->
                             case optionValue of
                                 OptionValue valueStr ->
-                                    selectOption option_ |> setLabel valueStr Nothing |> Debug.log "custom option selected"
+                                    selectOption option_ |> setLabel valueStr Nothing
 
                                 EmptyOptionValue ->
                                     selectOption option_
@@ -1255,6 +1262,29 @@ optionListContainsOptionWithValue option options =
 optionToValueLabelTuple : Option -> ( String, String )
 optionToValueLabelTuple option =
     ( getOptionValueAsString option, getOptionLabel option |> optionLabelToString )
+
+
+customSelectedOptions : List Option -> List Option
+customSelectedOptions =
+    customOptions >> selectedOptions
+
+
+customOptions : List Option -> List Option
+customOptions options =
+    List.filter isCustomOption options
+
+
+isCustomOption : Option -> Bool
+isCustomOption option =
+    case option of
+        Option _ _ _ _ _ ->
+            False
+
+        CustomOption _ _ _ ->
+            True
+
+        EmptyOption _ _ ->
+            False
 
 
 optionsDecoder : Json.Decode.Decoder (List Option)

--- a/src/Option.elm
+++ b/src/Option.elm
@@ -408,8 +408,20 @@ optionValuesEqual option optionValue =
 
 
 updateOrAddCustomOption : String -> List Option -> List Option
-updateOrAddCustomOption string options =
+updateOrAddCustomOption searchString options =
     let
+        showAddOption =
+            options
+                |> List.any
+                    (\option_ ->
+                        (option_
+                            |> getOptionLabel
+                            |> optionLabelToSearchString
+                        )
+                            == String.toLower searchString
+                    )
+                |> not
+
         options_ =
             List.Extra.dropWhile
                 (\option_ ->
@@ -425,12 +437,16 @@ updateOrAddCustomOption string options =
                 )
                 options
     in
-    [ CustomOption
-        OptionShown
-        (OptionLabel ("Add " ++ string ++ "…") Nothing)
-        (OptionValue string)
-    ]
-        ++ options_
+    if showAddOption then
+        [ CustomOption
+            OptionShown
+            (OptionLabel ("Add " ++ searchString ++ "…") Nothing)
+            (OptionValue searchString)
+        ]
+            ++ options_
+
+    else
+        options_
 
 
 highlightedOptionIndex : List Option -> Maybe Int

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -1,5 +1,6 @@
 port module Ports exposing
     ( addOptionsReceiver
+    , allowCustomOptionsReceiver
     , blurInput
     , deselectOptionReceiver
     , disableChangedReceiver
@@ -65,6 +66,9 @@ port disableChangedReceiver : (Bool -> msg) -> Sub msg
 
 
 port maxDropdownItemsChangedReceiver : (Int -> msg) -> Sub msg
+
+
+port allowCustomOptionsReceiver : (Bool -> msg) -> Sub msg
 
 
 port valueCasingDimensionsChangedReceiver : ({ width : Float, height : Float } -> msg) -> Sub msg

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -2,7 +2,7 @@ port module Ports exposing
     ( addOptionsReceiver
     , allowCustomOptionsReceiver
     , blurInput
-    , customOptionCreated
+    , customOptionSelected
     , deselectOptionReceiver
     , disableChangedReceiver
     , errorMessage
@@ -28,7 +28,7 @@ port errorMessage : String -> Cmd msg
 port valueChanged : List ( String, String ) -> Cmd msg
 
 
-port customOptionCreated : List String -> Cmd msg
+port customOptionSelected : List String -> Cmd msg
 
 
 port blurInput : () -> Cmd msg

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -2,6 +2,7 @@ port module Ports exposing
     ( addOptionsReceiver
     , allowCustomOptionsReceiver
     , blurInput
+    , customOptionCreated
     , deselectOptionReceiver
     , disableChangedReceiver
     , errorMessage
@@ -25,6 +26,9 @@ port errorMessage : String -> Cmd msg
 
 
 port valueChanged : List ( String, String ) -> Cmd msg
+
+
+port customOptionCreated : List String -> Cmd msg
 
 
 port blurInput : () -> Cmd msg

--- a/src/SelectionMode.elm
+++ b/src/SelectionMode.elm
@@ -1,4 +1,4 @@
-module SelectionMode exposing (CustomOptions(..), SelectionMode(..))
+module SelectionMode exposing (CustomOptions(..), SelectionMode(..), setAllowCustomOptionsWithBool)
 
 
 type CustomOptions
@@ -9,3 +9,21 @@ type CustomOptions
 type SelectionMode
     = SingleSelect CustomOptions
     | MultiSelect CustomOptions
+
+
+setAllowCustomOptionsWithBool : Bool -> SelectionMode -> SelectionMode
+setAllowCustomOptionsWithBool bool mode =
+    case mode of
+        SingleSelect _ ->
+            if bool then
+                SingleSelect AllowCustomOptions
+
+            else
+                SingleSelect NoCustomOptions
+
+        MultiSelect _ ->
+            if bool then
+                MultiSelect AllowCustomOptions
+
+            else
+                MultiSelect NoCustomOptions

--- a/src/SelectionMode.elm
+++ b/src/SelectionMode.elm
@@ -1,4 +1,4 @@
-module SelectionMode exposing (CustomOptions(..), SelectionMode(..), setAllowCustomOptionsWithBool)
+module SelectionMode exposing (CustomOptions(..), SelectionMode(..), getCustomOptions, setAllowCustomOptionsWithBool)
 
 
 type CustomOptions
@@ -9,6 +9,16 @@ type CustomOptions
 type SelectionMode
     = SingleSelect CustomOptions
     | MultiSelect CustomOptions
+
+
+getCustomOptions : SelectionMode -> CustomOptions
+getCustomOptions selectionMode =
+    case selectionMode of
+        SingleSelect customOptions ->
+            customOptions
+
+        MultiSelect customOptions ->
+            customOptions
 
 
 setAllowCustomOptionsWithBool : Bool -> SelectionMode -> SelectionMode

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -244,6 +244,11 @@ class MuchSelect extends HTMLElement {
         this.valueChangedHandler.bind(this)
       );
 
+      // noinspection JSUnresolvedVariable
+      this._app.ports.customOptionCreated.subscribe(
+        this.customOptionSelected.bind(this)
+      );
+
       // noinspection JSUnresolvedVariable,JSIgnoredPromiseFromCall
       this._app.ports.blurInput.subscribe(() => {
         const inputFilterElement = this.shadowRoot.getElementById(
@@ -387,7 +392,7 @@ class MuchSelect extends HTMLElement {
       this.hasAttribute("multi-select") &&
       this.getAttribute("multi-select") !== "false"
     ) {
-      // If we are in mulit select mode put the list of values in the event.
+      // If we are in multi select mode put the list of values in the event.
       const valuesObj = valuesTuple.map((valueTuple) => ({
         value: valueTuple[0],
         label: valueTuple[1],
@@ -419,6 +424,39 @@ class MuchSelect extends HTMLElement {
       // If we are in single select mode and there is more than one value then something is wrong.
       throw new TypeError(
         `In single select mode we are expecting a single value, instead we got ${valuesTuple.length}`
+      );
+    }
+  }
+
+  customOptionSelected(values) {
+    if (
+      this.hasAttribute("multi-select") &&
+      this.getAttribute("multi-select") !== "false" &&
+      values.length > 0
+    ) {
+      // If we are in multi select mode put the list of values in the event.
+      this.dispatchEvent(
+        new CustomEvent("customValueSelected", {
+          bubbles: true,
+          detail: {
+            values,
+          },
+        })
+      );
+    } else if (values.length === 1) {
+      // If we are in single select mode put the list of values in the event.
+      this.dispatchEvent(
+        new CustomEvent("customValueSelected", {
+          bubbles: true,
+          detail: {
+            value: values[0],
+          },
+        })
+      );
+    } else {
+      // If we are in single select mode and there is not one value then something is wrong.
+      throw new TypeError(
+        `In single select mode we are expecting a single custom option, instead we got ${values.length}`
       );
     }
   }
@@ -789,4 +827,5 @@ class MuchSelect extends HTMLElement {
   }
 }
 
+// noinspection JSUnusedGlobalSymbols
 export default MuchSelect;

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -245,7 +245,7 @@ class MuchSelect extends HTMLElement {
       );
 
       // noinspection JSUnresolvedVariable
-      this._app.ports.customOptionCreated.subscribe(
+      this._app.ports.customOptionSelected.subscribe(
         this.customOptionSelected.bind(this)
       );
 


### PR DESCRIPTION
Adding the `customValueSelected` event.

Don't show the "Add <whatever>..." option if the search string is an exact match for one of the existing options.