### PR TITLE
deselectItem Custom Event

### DIFF
--- a/public/events.html
+++ b/public/events.html
@@ -129,7 +129,8 @@
       });
     </script>
   </div>
-
+  </div>
+<div class="container">
   <div id="search-keyboard-events">
     <h3>Search/Filter Keyboard Events</h3>
     <much-select>
@@ -212,10 +213,10 @@
     <h3>Single Select - <code>deselectItem</code> Event</h3>
     <much-select>
       <select>
-        <option>String Beans</option>
-        <option>Lima Beans</option>
-        <option>White Beans</option>
-        <option>Red Beans</option>
+        <option value="4_99">String Beans</option>
+        <option value="5_99">Lima Beans</option>
+        <option value="1_08">White Beans</option>
+        <option value="3_92">Red Beans</option>
       </select>
     </much-select>
 

--- a/public/events.html
+++ b/public/events.html
@@ -129,7 +129,7 @@
       });
     </script>
   </div>
-  </div>
+</div>
 <div class="container">
   <div id="search-keyboard-events">
     <h3>Search/Filter Keyboard Events</h3>

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -390,7 +390,6 @@ update msg model =
                 SingleSelect _ ->
                     if Option.hasSelectedOption model.options then
                         -- if there are ANY selected options, clear them all;
-                        -- this will need to be addressed for multiselect (Jachin mentioned this)
                         clearAllSelectedOption model
 
                     else
@@ -428,14 +427,13 @@ update msg model =
 clearAllSelectedOption : Model -> ( Model, Cmd Msg )
 clearAllSelectedOption model =
     let
-        -- this whole thing likely needs to end up in makeCommandMessagesWhenValuesChanges
         deselectedItems =
             if List.isEmpty <| Option.selectedOptionsToTuple model.options then
-                -- there are no deselected options. Shouldn't ever get here.
+                -- no deselected options
                 []
 
             else
-                -- we have a deselect happening. return the deselected value as a tuple.
+                -- an option has been deselected. return the deselected value as a tuple.
                 Option.selectedOptionsToTuple model.options
 
         deselectEventMsg =
@@ -443,7 +441,6 @@ clearAllSelectedOption model =
                 Cmd.none
 
             else
-                -- encode deselectedItems because deselectItem is a Port to JS
                 deselectItem deselectedItems
     in
     ( { model

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -54,7 +54,7 @@ port blurInput : () -> Cmd msg
 port focusInput : () -> Cmd msg
 
 
-port deselectItem : () -> Cmd msg
+port deselectItem : List ( String, String ) -> Cmd msg
 
 
 valuesDecoder : Json.Decode.Decoder (List String)

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -326,10 +326,14 @@ class MuchSelect extends HTMLElement {
 
       // noinspection JSUnresolvedVariable,JSIgnoredPromiseFromCall
       this._app.ports.deselectItem.subscribe((deselectedValue) => {
+        const formattedValue = {
+          label: deselectedValue[0][1],
+          value: deselectedValue[0][0],
+        };
         this.dispatchEvent(
           new CustomEvent("deselectItem", {
             bubbles: true,
-            detail: { values: deselectedValue },
+            detail: formattedValue,
           })
         );
       });


### PR DESCRIPTION
When deselecting an option in a single select, emit a `deselectItem` CustomEvent that include the deselected options value and label.

In the sandbox: 
![deselect](https://user-images.githubusercontent.com/1396405/106637733-b09c0e00-6548-11eb-88dc-9467bfb0caa9.gif)
