### PR TITLE
Example saving a custom option

### DIFF
--- a/public/event-logger.js
+++ b/public/event-logger.js
@@ -9,19 +9,16 @@ const makeLogEventHandler = (logElementId) => {
       <strong><code>${event.type}</code></strong>
     </td>
     <td><code>${detailStr}</code></td>`;
-    document
-      .getElementById(logElementId)
-      .querySelector("tbody")
-      .prepend(tr);
+    document.getElementById(logElementId).querySelector("tbody").prepend(tr);
 
     window.setTimeout(() => {
-      let logItemNode = document.getElementById(eventElementId);
+      const logItemNode = document.getElementById(eventElementId);
       if (logItemNode.parentNode) {
         logItemNode.parentNode.removeChild(logItemNode);
       }
-    }, 5000)
-  }
+    }, 5000);
+  };
   return logEvent;
-}
+};
 
 export default makeLogEventHandler;

--- a/public/events.html
+++ b/public/events.html
@@ -22,6 +22,61 @@
 </nav>
 
 <div class="container">
+
+  <div id="much-select-ready-event">
+    <h3><code>muchSelectReady</code> Event</h3>
+    <much-select>
+      <select>
+        <option>Dogbert</option>
+        <option>Dilbert</option>
+        <option>Catbert</option>
+        <option>Bob the Dinosaur</option>
+      </select>
+    </much-select>
+
+    <button>Remove this much select a new one</button>
+
+    <p>
+      Events:
+    </p>
+    <table id="much-select-ready-event-log">
+      <thead>
+      <tr>
+        <th>Event</th>
+        <th>Details</th>
+      </tr>
+      </thead>
+      <tbody>
+      </tbody>
+    </table>
+    <script>
+      window.addEventListener("load", () => {
+        document
+          .querySelector("#much-select-ready-event much-select")
+          .addEventListener(
+            "muchSelectReady",
+            makeLogEventHandler("much-select-ready-event-log")
+          );
+      });
+
+      document.querySelector("#much-select-ready-event button").addEventListener("click", () => {
+        const oldMuchSelect = document
+          .querySelector("#much-select-ready-event much-select");
+
+        const newMuchSelect = document.createElement("much-select");
+
+        newMuchSelect.addEventListener(
+          "muchSelectReady",
+          makeLogEventHandler("much-select-ready-event-log")
+        );
+
+        document
+          .querySelector("#much-select-ready-event")
+          .replaceChild(newMuchSelect, oldMuchSelect);
+      });
+    </script>
+  </div>
+
   <div id="single-select-value-changed-event">
     <h3>Single Select - <code>valueChanged</code> Event</h3>
     <much-select>

--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!--suppress HtmlFormInputWithoutLabel -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -360,9 +361,33 @@
           "#custom-options-that-persist much-select"
         );
 
-        muchSelect.addEventListener("customValueSelected", (evt) => {
-          console.log("customValueSelected", evt);
-        });
+        muchSelect.addEventListener("muchSelectReady", () => {
+          // We can't go adding options to the much select until it's good and ready.
+          const localStorageKey = "custom-options-that-persist";
+
+          const customOptionsAsString = window.localStorage.getItem(localStorageKey);
+          if (customOptionsAsString === null) {
+            // This is the first time we are seeing this, save an empty array
+            //  for future custom options.
+            const emptySetOfOptions = [];
+            const emptySetOfOptionString = JSON.stringify(emptySetOfOptions);
+            window.localStorage.setItem(localStorageKey, emptySetOfOptionString)
+          } else {
+            // The table is set. We may have some custom options.
+            const customOptions = JSON.parse(customOptionsAsString);
+            muchSelect.addOptions(customOptions);
+          }
+
+          muchSelect.addEventListener("customValueSelected", (evt) => {
+            const newValue = evt.detail.value;
+            let customOptionsAsString = window.localStorage.getItem(localStorageKey);
+            const customOptions = JSON.parse(customOptionsAsString);
+            customOptions.push(newValue);
+            customOptionsAsString = JSON.stringify(customOptions);
+            window.localStorage.setItem(localStorageKey, customOptionsAsString);
+          });
+        })
+
       })();
     </script>
   </div>

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -271,6 +271,8 @@ class MuchSelect extends HTMLElement {
         evt.stopImmediatePropagation();
         evt.preventDefault();
       });
+
+      this.dispatchEvent(new CustomEvent("muchSelectReady"));
     });
 
     // noinspection JSUnresolvedVariable,JSIgnoredPromiseFromCall


### PR DESCRIPTION
This should address #44.

This finishes up the example of persisting custom examples and re-adding them next time the page is loaded.

I also added an example for the `muchSelectReady` event which was needed.