### PR TITLE
Fixing json-encoded empty selected values

### DIFF
--- a/src/much-select.js
+++ b/src/much-select.js
@@ -821,6 +821,7 @@ class MuchSelect extends HTMLElement {
           resolve(this._app);
         } catch (error) {
           reject(error);
+          this.errorHandler(error);
         }
       }
     });
@@ -890,7 +891,15 @@ class MuchSelect extends HTMLElement {
     }
     if (this.selectedValueEncoding === "json") {
       if (this.isInMultiSelectMode) {
+        if (this.selectedValue === "") {
+          // a special case because an empty string is not valid JSON.
+          return [];
+        }
         return JSON.parse(decodeURIComponent(this.selectedValue));
+      }
+      if (this.selectedValue === "") {
+        // a special case because an empty string is not valid JSON.
+        return "";
       }
       const val = JSON.parse(decodeURIComponent(this.selectedValue));
       if (Array.isArray(val)) {

--- a/tests/Attributes/selected-value.test.html
+++ b/tests/Attributes/selected-value.test.html
@@ -110,11 +110,38 @@
             { value: "5", description: "", label: "You", isSelected: false },
           ]);
         });
+
+        it("works in mulit select mode with an empty selected value", async () => {
+          const el = /** @type {MuchSelect} */ await fixture(html` <much-select
+            multi-select
+            selected-value-encoding="json"
+            selected-value=""
+          >
+          </much-select>`);
+
+          // The parsed selected value should be an empty array.
+          expect(el.parsedSelectedValue).to.eql([]);
+
+          // The selected value should be an empty string.
+          expect(el.selectedValue).to.equal("");
+        });
+
+        it("works in select mode with an empty selected value", async () => {
+          const el = /** @type {MuchSelect} */ await fixture(html` <much-select
+            selected-value-encoding="json"
+            selected-value=""
+          >
+          </much-select>`);
+
+          // The parsed selected value should be an empty array.
+          expect(el.parsedSelectedValue).to.eql("");
+
+          // The selected value should be an empty string.
+          expect(el.selectedValue).to.equal("");
+        });
       });
     });
   });
 </script>
 </body>
 </html>
-
-

--- a/tests/Slots/select-input-slot.test.html
+++ b/tests/Slots/select-input-slot.test.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<body>
+<script type="module">
+  import { runTests } from "@web/test-runner-mocha";
+  import { expect } from "@esm-bundle/chai";
+  import { html, fixture } from "@open-wc/testing";
+
+  import MuchSelect from "../../dist/much-select-debug.js";
+
+  if (!customElements.get("much-select")) {
+    // Putting guard rails around this because browsers do not like
+    //  having the same custom element defined more than once.
+    window.customElements.define("much-select", MuchSelect);
+  }
+
+  runTests(() => {
+    describe("Slots", () => {
+      describe("select-input", () => {
+        it("should be able to handle options with commas in them.", async () => {
+          const el = /** @type {MuchSelect} */ await fixture(
+            html`<much-select
+              class="pa-2"
+              id="much-subscriber.applied_tag"
+              data-slug="subscriber.applied_tag"
+              multi-select=""
+              placeholder="type or select..."
+              size="large"
+              selected-value=""
+              selected-value-encoding="json"
+              style=""
+            >
+              <select>
+                <option value="a tag for david">a tag for david</option>
+                <option value="a tag for mike">a tag for mike</option>
+                <option value="an unsanitized, tag to break things">
+                  an unsanitized, tag to break things
+                </option>
+                <option value="tag 1">tag 1</option>
+                <option value="tag 2">tag 2</option>
+                <option value="tag 4">tag 4</option>
+                <option value="tom's tag">tom's tag</option>
+              </select>
+              <input
+                type="hidden"
+                name="webhook_builder[filter_values][subscriber.applied_tag][]"
+                slot="hidden-value-input"
+                value=""
+              />
+              <div slot="loading-indicator">
+                <loading-orb style="margin-right: 5px;"></loading-orb>
+              </div>
+            </much-select>`
+          );
+
+          const allOptions = await el.getAllOptions();
+
+          expect(allOptions).to.have.length(7);
+        });
+      });
+    });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
If a selected value is empty and we're doing json encoding, there were a couple bugs.

Adding unit tests for this behavior too.