### PR TITLE
An example for the multi-select-single-item-removal attribute

### DIFF
--- a/public/multi-select.html
+++ b/public/multi-select.html
@@ -61,8 +61,9 @@
   <div id="much-select-with-removable-options">
     <h3>Removable Options</h3>
     <p>With multi select you can make each selected value individually removable.</p>
-    <much-select multi-select="" allow-custom-options="" multi-select-single-item-removal="true">
-      <select>
+    <button>Toggle the remove selected item buttons</button>
+    <much-select multi-select allow-custom-options multi-select-single-item-removal  selected-value="Butterhead,Escarole">
+      <select slot="select-input">
         <option>Arugula</option>
         <option>Butterhead</option>
         <option>Coral</option>
@@ -73,6 +74,15 @@
         <option>Mâche</option>
       </select>
     </much-select>
+    <script>
+      document
+        .querySelector("#much-select-with-removable-options button")
+        .addEventListener("click", () => {
+          document
+            .querySelector("#much-select-with-removable-options much-select")
+            .toggleAttribute("multi-select-single-item-removal");
+        });
+    </script>
 
   </div>
   <div id="much-select-with-no-options">

--- a/public/multi-select.html
+++ b/public/multi-select.html
@@ -62,7 +62,7 @@
     <h3>Removable Options</h3>
     <p>With multi select you can make each selected value individually removable.</p>
     <button>Toggle the remove selected item buttons</button>
-    <much-select multi-select allow-custom-options multi-select-single-item-removal  selected-value="Butterhead,Escarole">
+    <much-select multi-select allow-custom-options multi-select-single-item-removal selected-value="Butterhead,Escarole">
       <select slot="select-input">
         <option>Arugula</option>
         <option>Butterhead</option>

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1300,6 +1300,15 @@ optionToDropdownOption mouseOverMsgConstructor mouseOutMsgConstructor clickMsgCo
 
 optionsToValuesHtml : List Option -> SingleItemRemoval -> List (Html Msg)
 optionsToValuesHtml options enableSingleItemRemoval =
+    let
+        labelHtml labelText optionValue =
+            span
+                [ class "value-label"
+                , mousedownPreventDefaultAndStopPropagation
+                    (ToggleSelectedValueHighlight optionValue)
+                ]
+                [ text labelText ]
+    in
     options
         |> Option.selectedOptions
         |> List.map
@@ -1310,7 +1319,7 @@ optionsToValuesHtml options enableSingleItemRemoval =
                             removalHtml =
                                 case enableSingleItemRemoval of
                                     EnableSingleItemRemoval ->
-                                        span [ onClick <| DeselectOptionInternal option ] [ text "remove" ]
+                                        span [ mousedownPreventDefaultAndStopPropagation <| DeselectOptionInternal option, class "remove-option" ] [ text "" ]
 
                                     DisableSingleItemRemoval ->
                                         text ""
@@ -1325,10 +1334,8 @@ optionsToValuesHtml options enableSingleItemRemoval =
                             OptionSelected _ ->
                                 div
                                     [ class "value"
-                                    , mousedownPreventDefaultAndStopPropagation
-                                        (ToggleSelectedValueHighlight optionValue)
                                     ]
-                                    [ text (OptionLabel.getLabelString optionLabel), removalHtml ]
+                                    [ labelHtml (OptionLabel.getLabelString optionLabel) optionValue, removalHtml ]
 
                             OptionSelectedHighlighted _ ->
                                 div
@@ -1336,10 +1343,8 @@ optionsToValuesHtml options enableSingleItemRemoval =
                                         [ ( "value", True )
                                         , ( "highlighted-value", True )
                                         ]
-                                    , mousedownPreventDefaultAndStopPropagation
-                                        (ToggleSelectedValueHighlight optionValue)
                                     ]
-                                    [ text (OptionLabel.getLabelString optionLabel), removalHtml ]
+                                    [ labelHtml (OptionLabel.getLabelString optionLabel) optionValue, removalHtml ]
 
                             OptionHighlighted ->
                                 text ""
@@ -1361,7 +1366,7 @@ optionsToValuesHtml options enableSingleItemRemoval =
                                     , mousedownPreventDefaultAndStopPropagation
                                         (ToggleSelectedValueHighlight optionValue)
                                     ]
-                                    [ text (OptionLabel.getLabelString optionLabel) ]
+                                    [ labelHtml (OptionLabel.getLabelString optionLabel) optionValue ]
 
                             OptionSelectedHighlighted _ ->
                                 div
@@ -1369,10 +1374,8 @@ optionsToValuesHtml options enableSingleItemRemoval =
                                         [ ( "value", True )
                                         , ( "highlighted-value", True )
                                         ]
-                                    , mousedownPreventDefaultAndStopPropagation
-                                        (ToggleSelectedValueHighlight optionValue)
                                     ]
-                                    [ text (OptionLabel.getLabelString optionLabel) ]
+                                    [ labelHtml (OptionLabel.getLabelString optionLabel) optionValue ]
 
                             OptionHighlighted ->
                                 text ""

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -1104,14 +1104,29 @@ class MuchSelect extends HTMLElement {
   }
 
   set isInMultiSelectModeWithSingleItemRemoval(value) {
-    if (!this._isInMultiSelectMode) {
-      this._isInMultiSelectModeWithSingleItemRemoval = false;
-    } else if (value === "false") {
+    if (value === "false") {
       this._isInMultiSelectModeWithSingleItemRemoval = false;
     } else if (value === "") {
       this._isInMultiSelectModeWithSingleItemRemoval = true;
     } else {
       this._isInMultiSelectModeWithSingleItemRemoval = !!value;
+    }
+
+    if (!this.eventsOnlyMode) {
+      if (this._isInMultiSelectModeWithSingleItemRemoval) {
+        this.setAttribute(
+          "multi-select-single-item-removal",
+          "multi-select-single-item-removal"
+        );
+      } else {
+        this.removeAttribute("multi-select-single-item-removal");
+      }
+      // noinspection JSUnresolvedVariable
+      this.appPromise.then((app) =>
+        app.ports.multiSelectSingleItemRemovalChangedReceiver.send(
+          this._isInMultiSelectModeWithSingleItemRemoval
+        )
+      );
     }
   }
 
@@ -1420,6 +1435,11 @@ class MuchSelect extends HTMLElement {
       #value-casing.multi .value.highlighted-value {
         background-image: linear-gradient(to bottom, #d99477, #efb680);
         background-repeat: repeat-x;
+      }
+
+      .value .remove-option::after {
+        content: "x";
+        padding-left: 5px;
       }
 
       #dropdown-indicator {

--- a/tests/IntegrationTests/options.test.html
+++ b/tests/IntegrationTests/options.test.html
@@ -51,7 +51,7 @@
           );
           expect(el.selectedValue).to.equal("table");
           expect(el.shadowRoot.querySelectorAll(".value")[0].innerHTML).to.equal(
-            "table"
+            '<span class="value-label">table</span>'
           );
           expect(el.shadowRoot.querySelectorAll(".value").length).to.equal(1);
         });


### PR DESCRIPTION
Fixes #56

Changing up the markup a bit for the buttons (in the `value` s) to deselected the selected options (in multi select mode)

Adding an example.

https://user-images.githubusercontent.com/42679/152610208-05a93e3a-04ae-428c-8799-c2fedf501225.mov


