### PR TITLE
Do not emmit `value-changed` event durring initalization

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -67,6 +67,7 @@ import Ports
         , disableChangedReceiver
         , errorMessage
         , focusInput
+        , initialValueSet
         , inputBlurred
         , inputKeyUp
         , loadingChangedReceiver
@@ -1486,7 +1487,7 @@ makeCommandMessageForInitialValue selectedOptions =
             Cmd.none
 
         selectionOptions_ ->
-            valueChanged (selectedOptionsToTuple selectionOptions_)
+            initialValueSet (selectedOptionsToTuple selectionOptions_)
 
 
 type alias Flags =

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -9,6 +9,7 @@ port module Ports exposing
     , disableChangedReceiver
     , errorMessage
     , focusInput
+    , initialValueSet
     , inputBlurred
     , inputKeyUp
     , loadingChangedReceiver
@@ -43,6 +44,9 @@ port errorMessage : String -> Cmd msg
 
 
 port valueChanged : List ( String, String ) -> Cmd msg
+
+
+port initialValueSet : List ( String, String ) -> Cmd msg
 
 
 port customOptionSelected : List String -> Cmd msg


### PR DESCRIPTION
During the initialization process, if we parse the `select-input` slot and end up updating the options and the selected value as part of that process, we do not want to emit a `value-changed` event as part of that process.