### PR TITLE
98 filtering could be better

### DIFF
--- a/elm-tooling.json
+++ b/elm-tooling.json
@@ -4,6 +4,7 @@
     ],
     "tools": {
         "elm": "0.19.1",
-        "elm-format": "0.8.5"
+        "elm-format": "0.8.5",
+        "elm-json": "0.2.8"
     }
 }

--- a/elm.json
+++ b/elm.json
@@ -10,7 +10,8 @@
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
-            "elm-community/list-extra": "8.2.4",
+            "elm-community/list-extra": "8.5.2",
+            "elm-community/maybe-extra": "5.3.0",
             "elm-community/string-extra": "4.0.1",
             "mhoare/elm-stack": "3.1.2",
             "ohanhi/keyboard": "2.0.1",
@@ -27,7 +28,7 @@
     },
     "test-dependencies": {
         "direct": {
-            "avh4/elm-program-test": "3.4.0",
+            "avh4/elm-program-test": "3.6.3",
             "elm-explorations/test": "1.2.2"
         },
         "indirect": {
@@ -37,6 +38,8 @@
             "elm/http": "2.0.0",
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
+            "hecrj/html-parser": "2.4.0",
+            "mgold/elm-nonempty-list": "4.2.0",
             "rtfeldman/elm-hex": "1.0.0"
         }
     }

--- a/src/Option.elm
+++ b/src/Option.elm
@@ -21,6 +21,7 @@ module Option exposing
     , emptyOptionGroup
     , encode
     , filterOptionsToShowInDropdown
+    , filterOptionsToShowInDropdownBySearchScore
     , findHighestAutoSortRank
     , findHighlightedOrSelectedOptionIndex
     , findOptionByOptionValue
@@ -83,8 +84,9 @@ module Option exposing
 import Json.Decode
 import Json.Encode
 import List.Extra
+import Maybe.Extra
 import OptionLabel exposing (OptionLabel(..), getSortRank, labelDecoder, optionLabelToSearchString, optionLabelToString)
-import OptionSearchFilter exposing (OptionSearchFilter)
+import OptionSearchFilter exposing (OptionSearchFilter, OptionSearchResult, getLowScore, impossiblyLowScore, lowScoreCutOff)
 import SelectionMode exposing (SelectedItemPlacementMode(..), SelectionMode(..))
 import SortRank exposing (SortRank(..), getAutoIndexForSorting)
 
@@ -981,6 +983,11 @@ findHighlightedOrSelectedOptionIndex options =
 
 filterOptionsToShowInDropdown : List Option -> List Option
 filterOptionsToShowInDropdown =
+    filterOptionsToShowInDropdownByOptionDisplay >> filterOptionsToShowInDropdownBySearchScore
+
+
+filterOptionsToShowInDropdownByOptionDisplay : List Option -> List Option
+filterOptionsToShowInDropdownByOptionDisplay =
     List.filter
         (\option ->
             case getOptionDisplay option of
@@ -1002,6 +1009,57 @@ filterOptionsToShowInDropdown =
                 OptionDisabled ->
                     True
         )
+
+
+filterOptionsToShowInDropdownBySearchScore : List Option -> List Option
+filterOptionsToShowInDropdownBySearchScore options =
+    case findLowestSearchScore options of
+        Just lowScore ->
+            List.filter (isOptionBelowScore (lowScoreCutOff lowScore)) options
+
+        Nothing ->
+            options
+
+
+findLowestSearchScore : List Option -> Maybe Int
+findLowestSearchScore options =
+    let
+        lowSore =
+            options
+                |> optionSearchResults
+                |> List.foldl
+                    (\searchResult lowScore ->
+                        if getLowScore searchResult < lowScore then
+                            getLowScore searchResult
+
+                        else
+                            lowScore
+                    )
+                    impossiblyLowScore
+    in
+    if lowSore == impossiblyLowScore then
+        Nothing
+
+    else
+        Just (Debug.log "low score" lowSore)
+
+
+optionSearchResults : List Option -> List OptionSearchResult
+optionSearchResults options =
+    options
+        |> List.map getMaybeOptionSearchFilter
+        |> Maybe.Extra.values
+        |> List.map .searchResult
+
+
+isOptionBelowScore : Int -> Option -> Bool
+isOptionBelowScore score option =
+    case getMaybeOptionSearchFilter option of
+        Just optionSearchFilter ->
+            score >= getLowScore optionSearchFilter.searchResult
+
+        Nothing ->
+            False
 
 
 highlightOptionInList : Option -> List Option -> List Option

--- a/src/Option.elm
+++ b/src/Option.elm
@@ -1041,7 +1041,7 @@ findLowestSearchScore options =
         Nothing
 
     else
-        Just (Debug.log "low score" lowSore)
+        lowSore
 
 
 optionSearchResults : List Option -> List OptionSearchResult

--- a/src/Option.elm
+++ b/src/Option.elm
@@ -1041,7 +1041,7 @@ findLowestSearchScore options =
         Nothing
 
     else
-        lowSore
+        Just lowSore
 
 
 optionSearchResults : List Option -> List OptionSearchResult

--- a/src/OptionSearchFilter.elm
+++ b/src/OptionSearchFilter.elm
@@ -1,4 +1,4 @@
-module OptionSearchFilter exposing (OptionSearchFilter, OptionSearchResult, new)
+module OptionSearchFilter exposing (OptionSearchFilter, OptionSearchResult, getLowScore, impossiblyLowScore, lowScoreCutOff, new)
 
 import Fuzzy exposing (Result)
 
@@ -17,6 +17,11 @@ type alias OptionSearchResult =
     }
 
 
+impossiblyLowScore : number
+impossiblyLowScore =
+    1000000
+
+
 new : Int -> OptionSearchResult -> List ( Bool, String ) -> List ( Bool, String ) -> OptionSearchFilter
 new totalScore searchResult labelTokens descriptionTokens =
     { totalScore = totalScore
@@ -24,3 +29,30 @@ new totalScore searchResult labelTokens descriptionTokens =
     , labelTokens = labelTokens
     , descriptionTokens = descriptionTokens
     }
+
+
+getLowScore : OptionSearchResult -> Int
+getLowScore optionSearchResult =
+    if optionSearchResult.labelMatch.score < optionSearchResult.descriptionMatch.score then
+        optionSearchResult.labelMatch.score
+
+    else
+        optionSearchResult.descriptionMatch.score
+
+
+lowScoreCutOff : Int -> Int
+lowScoreCutOff score =
+    if score == 0 then
+        0
+
+    else if score <= 10 then
+        10
+
+    else if score <= 100 then
+        100
+
+    else if score <= 1000 then
+        1000
+
+    else
+        impossiblyLowScore

--- a/tests/FilteringOptions/MaxNumberOfDropdownItems.elm
+++ b/tests/FilteringOptions/MaxNumberOfDropdownItems.elm
@@ -3,7 +3,9 @@ module FilteringOptions.MaxNumberOfDropdownItems exposing (suite)
 import Expect
 import Main exposing (figureOutWhichOptionsToShow)
 import Option exposing (highlightOptionInList, newOption, selectOptionInList, setGroupWithString)
+import OptionSearcher
 import PositiveInt
+import SelectionMode exposing (CustomOptions(..), SelectedItemPlacementMode(..), SelectionMode(..), SingleItemRemoval(..))
 import Test exposing (Test, describe, test)
 
 
@@ -83,6 +85,13 @@ six =
 
 three =
     PositiveInt.new 3
+
+
+equalOptionListValues : List Option.Option -> List Option.Option -> Expect.Expectation
+equalOptionListValues optionsA optionsB =
+    Expect.equalLists
+        (List.map Option.getOptionValue optionsA)
+        (List.map Option.getOptionValue optionsB)
 
 
 suite : Test
@@ -273,6 +282,21 @@ suite =
                             (tools
                                 |> highlightOptionInList wrench
                                 |> selectOptionInList xActoKnife
+                            )
+                        )
+            ]
+        , describe "if there are strong matches"
+            [ test "we should hide everything else" <|
+                \_ ->
+                    equalOptionListValues
+                        (highlightOptionInList wrench
+                            [ wrench
+                            ]
+                        )
+                        (figureOutWhichOptionsToShow three
+                            (tools
+                                |> OptionSearcher.updateOptions (MultiSelect NoCustomOptions DisableSingleItemRemoval) Nothing "wrench"
+                                |> highlightOptionInList wrench
                             )
                         )
             ]


### PR DESCRIPTION
Once a user starts searching for an option, be more aggressive at **not** showing options that don't match very well.

Before: 
https://user-images.githubusercontent.com/42679/156834658-f17d04a3-91d1-49a6-ba29-cdba7e4b51fb.mov

After:
https://user-images.githubusercontent.com/42679/156834705-48b93ada-e5e6-40eb-a33a-6a476774db50.mov


