### PR TITLE
106: don't stop propegatin

### DIFF
--- a/public/multi-select-examples/custom-options.html
+++ b/public/multi-select-examples/custom-options.html
@@ -18,7 +18,7 @@
   <much-select multi-select="" allow-custom-options="">
     <select slot="select-input">
       <option>Caveman</option>
-      <option>Beas</option>
+      <option>Bees</option>
       <option>Cow</option>
       <option>Scientist</option>
       <option>Angel</option>

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1066,6 +1066,14 @@ dropdownIndicator focused disabled =
             [ text "▾" ]
 
 
+type alias DropdownItemEventListeners msg =
+    { mouseOverMsgConstructor : OptionValue -> msg
+    , mouseOutMsgConstructor : OptionValue -> msg
+    , clickMsgConstructor : OptionValue -> msg
+    , noOpMsgConstructor : msg
+    }
+
+
 dropdown : Model -> Html Msg
 dropdown model =
     let
@@ -1075,10 +1083,11 @@ dropdown model =
 
             else
                 optionsToDropdownOptions
-                    DropdownMouseOverOption
-                    DropdownMouseOutOption
-                    DropdownMouseClickOption
-                    NoOp
+                    { mouseOverMsgConstructor = DropdownMouseOverOption
+                    , mouseOutMsgConstructor = DropdownMouseOutOption
+                    , clickMsgConstructor = DropdownMouseClickOption
+                    , noOpMsgConstructor = NoOp
+                    }
                     model.selectionMode
                     model.optionsForTheDropdown
 
@@ -1128,24 +1137,18 @@ dropdown model =
 
 
 optionsToDropdownOptions :
-    (OptionValue -> msg)
-    -> (OptionValue -> msg)
-    -> (OptionValue -> msg)
-    -> msg
+    DropdownItemEventListeners Msg
     -> SelectionMode
     -> List Option
-    -> List (Html msg)
-optionsToDropdownOptions mouseOverMsgConstructor mouseOutMsgConstructor clickMsgConstructor noOpMsgConstructor selectionMode options =
+    -> List (Html Msg)
+optionsToDropdownOptions eventHandlers selectionMode options =
     let
         partialWithSelectionMode =
             optionToDropdownOption
-                mouseOverMsgConstructor
-                mouseOutMsgConstructor
-                clickMsgConstructor
-                noOpMsgConstructor
+                eventHandlers
                 selectionMode
 
-        helper : OptionGroup -> Option -> ( OptionGroup, List (Html msg) )
+        helper : OptionGroup -> Option -> ( OptionGroup, List (Html Msg) )
         helper previousGroup option_ =
             ( Option.getOptionGroup option_
             , option_ |> partialWithSelectionMode (previousGroup /= Option.getOptionGroup option_)
@@ -1159,15 +1162,12 @@ optionsToDropdownOptions mouseOverMsgConstructor mouseOutMsgConstructor clickMsg
 
 
 optionToDropdownOption :
-    (OptionValue -> msg)
-    -> (OptionValue -> msg)
-    -> (OptionValue -> msg)
-    -> msg
+    DropdownItemEventListeners Msg
     -> SelectionMode
     -> Bool
     -> Option
-    -> List (Html msg)
-optionToDropdownOption mouseOverMsgConstructor mouseOutMsgConstructor clickMsgConstructor noOpMsgConstructor selectionMode prependOptionGroup option =
+    -> List (Html Msg)
+optionToDropdownOption eventHandlers selectionMode prependOptionGroup option =
     let
         optionGroupHtml =
             if prependOptionGroup then
@@ -1186,7 +1186,7 @@ optionToDropdownOption mouseOverMsgConstructor mouseOutMsgConstructor clickMsgCo
             else
                 text ""
 
-        descriptionHtml : Html msg
+        descriptionHtml : Html Msg
         descriptionHtml =
             if option |> Option.getOptionDescription |> Option.optionDescriptionToBool then
                 case Option.getMaybeOptionSearchFilter option of
@@ -1212,7 +1212,7 @@ optionToDropdownOption mouseOverMsgConstructor mouseOutMsgConstructor clickMsgCo
             else
                 text ""
 
-        labelHtml : Html msg
+        labelHtml : Html Msg
         labelHtml =
             case Option.getMaybeOptionSearchFilter option of
                 Just optionSearchFilter ->
@@ -1228,10 +1228,10 @@ optionToDropdownOption mouseOverMsgConstructor mouseOutMsgConstructor clickMsgCo
         OptionShown ->
             [ optionGroupHtml
             , div
-                [ onMouseEnter (option |> Option.getOptionValue |> mouseOverMsgConstructor)
-                , onMouseLeave (option |> Option.getOptionValue |> mouseOutMsgConstructor)
-                , mousedownPreventDefault (option |> Option.getOptionValue |> clickMsgConstructor)
-                , onClickPreventDefault noOpMsgConstructor
+                [ onMouseEnter (option |> Option.getOptionValue |> eventHandlers.mouseOverMsgConstructor)
+                , onMouseLeave (option |> Option.getOptionValue |> eventHandlers.mouseOutMsgConstructor)
+                , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.clickMsgConstructor)
+                , onClickPreventDefault eventHandlers.noOpMsgConstructor
                 , class "option"
                 , valueDataAttribute
                 ]
@@ -1246,9 +1246,9 @@ optionToDropdownOption mouseOverMsgConstructor mouseOutMsgConstructor clickMsgCo
                 SingleSelect _ _ ->
                     [ optionGroupHtml
                     , div
-                        [ onMouseEnter (option |> Option.getOptionValue |> mouseOverMsgConstructor)
-                        , onMouseLeave (option |> Option.getOptionValue |> mouseOutMsgConstructor)
-                        , mousedownPreventDefault (option |> Option.getOptionValue |> clickMsgConstructor)
+                        [ onMouseEnter (option |> Option.getOptionValue |> eventHandlers.mouseOverMsgConstructor)
+                        , onMouseLeave (option |> Option.getOptionValue |> eventHandlers.mouseOutMsgConstructor)
+                        , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.clickMsgConstructor)
                         , class "selected"
                         , class "option"
                         , valueDataAttribute
@@ -1264,9 +1264,9 @@ optionToDropdownOption mouseOverMsgConstructor mouseOutMsgConstructor clickMsgCo
                 SingleSelect _ _ ->
                     [ optionGroupHtml
                     , div
-                        [ onMouseEnter (option |> Option.getOptionValue |> mouseOverMsgConstructor)
-                        , onMouseLeave (option |> Option.getOptionValue |> mouseOutMsgConstructor)
-                        , mousedownPreventDefault (option |> Option.getOptionValue |> clickMsgConstructor)
+                        [ onMouseEnter (option |> Option.getOptionValue |> eventHandlers.mouseOverMsgConstructor)
+                        , onMouseLeave (option |> Option.getOptionValue |> eventHandlers.mouseOutMsgConstructor)
+                        , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.clickMsgConstructor)
                         , class "selected"
                         , class "highlighted"
                         , class "option"
@@ -1281,9 +1281,9 @@ optionToDropdownOption mouseOverMsgConstructor mouseOutMsgConstructor clickMsgCo
         OptionHighlighted ->
             [ optionGroupHtml
             , div
-                [ onMouseEnter (option |> Option.getOptionValue |> mouseOverMsgConstructor)
-                , onMouseLeave (option |> Option.getOptionValue |> mouseOutMsgConstructor)
-                , mousedownPreventDefault (option |> Option.getOptionValue |> clickMsgConstructor)
+                [ onMouseEnter (option |> Option.getOptionValue |> eventHandlers.mouseOverMsgConstructor)
+                , onMouseLeave (option |> Option.getOptionValue |> eventHandlers.mouseOutMsgConstructor)
+                , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.clickMsgConstructor)
                 , class "highlighted"
                 , class "option"
                 , valueDataAttribute
@@ -1681,7 +1681,7 @@ subscriptions _ =
 {-| Performs the mousedown event, but also prevent default.
 
 We used to also stop propagation but that is actually a problem because that stops all the click events
-default actions from being supressed (I think).
+default actions from being suppressed (I think).
 
 -}
 mousedownPreventDefault : msg -> Html.Attribute msg
@@ -1697,7 +1697,7 @@ mousedownPreventDefault message =
 
 {-| Performs the event onClick, but also prevent default.
 
-We used to also stop propigation but that is actually a problem because we want
+We used to also stop propagation but that is actually a problem because we want
 
 -}
 onClickPreventDefault : msg -> Html.Attribute msg

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1135,14 +1135,14 @@ optionsToDropdownOptions :
     -> SelectionMode
     -> List Option
     -> List (Html msg)
-optionsToDropdownOptions mouseOverMsgConstructor mouseOutMsgConstructor clickMsgConstructor noOpMegConstructor selectionMode options =
+optionsToDropdownOptions mouseOverMsgConstructor mouseOutMsgConstructor clickMsgConstructor noOpMsgConstructor selectionMode options =
     let
         partialWithSelectionMode =
             optionToDropdownOption
                 mouseOverMsgConstructor
                 mouseOutMsgConstructor
                 clickMsgConstructor
-                noOpMegConstructor
+                noOpMsgConstructor
                 selectionMode
 
         helper : OptionGroup -> Option -> ( OptionGroup, List (Html msg) )
@@ -1230,8 +1230,8 @@ optionToDropdownOption mouseOverMsgConstructor mouseOutMsgConstructor clickMsgCo
             , div
                 [ onMouseEnter (option |> Option.getOptionValue |> mouseOverMsgConstructor)
                 , onMouseLeave (option |> Option.getOptionValue |> mouseOutMsgConstructor)
-                , mousedownPreventDefaultAndStopPropagation (option |> Option.getOptionValue |> clickMsgConstructor)
-                , onClickPreventDefaultAndStopPropagation noOpMsgConstructor
+                , mousedownPreventDefault (option |> Option.getOptionValue |> clickMsgConstructor)
+                , onClickPreventDefault noOpMsgConstructor
                 , class "option"
                 , valueDataAttribute
                 ]
@@ -1248,7 +1248,7 @@ optionToDropdownOption mouseOverMsgConstructor mouseOutMsgConstructor clickMsgCo
                     , div
                         [ onMouseEnter (option |> Option.getOptionValue |> mouseOverMsgConstructor)
                         , onMouseLeave (option |> Option.getOptionValue |> mouseOutMsgConstructor)
-                        , mousedownPreventDefaultAndStopPropagation (option |> Option.getOptionValue |> clickMsgConstructor)
+                        , mousedownPreventDefault (option |> Option.getOptionValue |> clickMsgConstructor)
                         , class "selected"
                         , class "option"
                         , valueDataAttribute
@@ -1266,7 +1266,7 @@ optionToDropdownOption mouseOverMsgConstructor mouseOutMsgConstructor clickMsgCo
                     , div
                         [ onMouseEnter (option |> Option.getOptionValue |> mouseOverMsgConstructor)
                         , onMouseLeave (option |> Option.getOptionValue |> mouseOutMsgConstructor)
-                        , mousedownPreventDefaultAndStopPropagation (option |> Option.getOptionValue |> clickMsgConstructor)
+                        , mousedownPreventDefault (option |> Option.getOptionValue |> clickMsgConstructor)
                         , class "selected"
                         , class "highlighted"
                         , class "option"
@@ -1283,7 +1283,7 @@ optionToDropdownOption mouseOverMsgConstructor mouseOutMsgConstructor clickMsgCo
             , div
                 [ onMouseEnter (option |> Option.getOptionValue |> mouseOverMsgConstructor)
                 , onMouseLeave (option |> Option.getOptionValue |> mouseOutMsgConstructor)
-                , mousedownPreventDefaultAndStopPropagation (option |> Option.getOptionValue |> clickMsgConstructor)
+                , mousedownPreventDefault (option |> Option.getOptionValue |> clickMsgConstructor)
                 , class "highlighted"
                 , class "option"
                 , valueDataAttribute
@@ -1317,7 +1317,7 @@ optionToValueHtml enableSingleItemRemoval option =
                 removalHtml =
                     case enableSingleItemRemoval of
                         EnableSingleItemRemoval ->
-                            span [ mousedownPreventDefaultAndStopPropagation <| DeselectOptionInternal option, class "remove-option" ] [ text "" ]
+                            span [ mousedownPreventDefault <| DeselectOptionInternal option, class "remove-option" ] [ text "" ]
 
                         DisableSingleItemRemoval ->
                             text ""
@@ -1361,7 +1361,7 @@ optionToValueHtml enableSingleItemRemoval option =
                 OptionSelected _ ->
                     div
                         [ class "value"
-                        , mousedownPreventDefaultAndStopPropagation
+                        , mousedownPreventDefault
                             (ToggleSelectedValueHighlight optionValue)
                         ]
                         [ valueLabelHtml (OptionLabel.getLabelString optionLabel) optionValue ]
@@ -1406,7 +1406,7 @@ valueLabelHtml : String -> OptionValue -> Html Msg
 valueLabelHtml labelText optionValue =
     span
         [ class "value-label"
-        , mousedownPreventDefaultAndStopPropagation
+        , mousedownPreventDefault
             (ToggleSelectedValueHighlight optionValue)
         ]
         [ text labelText ]
@@ -1429,7 +1429,7 @@ rightSlotHtml rightSlot focused disabled =
         ShowClearButton ->
             div
                 [ id "clear-button-wrapper"
-                , onClickPreventDefaultAndStopPropagation ClearAllSelectedOptions
+                , onClickPreventDefault ClearAllSelectedOptions
                 ]
                 [ node "slot"
                     [ name "clear-button"
@@ -1678,26 +1678,34 @@ subscriptions _ =
         ]
 
 
-mousedownPreventDefaultAndStopPropagation : msg -> Html.Attribute msg
-mousedownPreventDefaultAndStopPropagation message =
+{-| Performs the mousedown event, but also prevent default.
+
+We used to also stop propagation but that is actually a problem because that stops all the click events
+default actions from being supressed (I think).
+
+-}
+mousedownPreventDefault : msg -> Html.Attribute msg
+mousedownPreventDefault message =
     Html.Events.custom "mousedown"
         (Json.Decode.succeed
             { message = message
-            , stopPropagation = True
+            , stopPropagation = False
             , preventDefault = True
             }
         )
 
 
-{-| Performs the event onClick, but also stops that click from propagating and
-prevents defaults to ensure the msg specified is the only action.
+{-| Performs the event onClick, but also prevent default.
+
+We used to also stop propigation but that is actually a problem because we want
+
 -}
-onClickPreventDefaultAndStopPropagation : msg -> Html.Attribute msg
-onClickPreventDefaultAndStopPropagation message =
+onClickPreventDefault : msg -> Html.Attribute msg
+onClickPreventDefault message =
     Html.Events.custom "click"
         (Json.Decode.succeed
             { message = message
-            , stopPropagation = True
+            , stopPropagation = False
             , preventDefault = True
             }
         )

--- a/src/OptionSearchFilter.elm
+++ b/src/OptionSearchFilter.elm
@@ -43,16 +43,16 @@ getLowScore optionSearchResult =
 lowScoreCutOff : Int -> Int
 lowScoreCutOff score =
     if score == 0 then
-        0
-
-    else if score <= 10 then
         10
 
-    else if score <= 100 then
+    else if score <= 10 then
         100
 
-    else if score <= 1000 then
+    else if score <= 100 then
         1000
+
+    else if score <= 1000 then
+        10000
 
     else
         impossiblyLowScore


### PR DESCRIPTION
From looking at the following example we need to allow propagation of the mouse down event in order for it to really prevent all the other click events from causing the input to lose focus triggering the blur event.

https://codepen.io/mudassir0909/pen/qBjvzL

There's also a bug fix here related to #98. There's an issue where if there's a custom option that one _always_ shows up as the best match. I fixed that by making the filtering a little bit more relaxed.