### PR TITLE
115: Add the search-string-minium-length attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The `placeholder` attribute is used to set the placeholder in the text input of 
 
 ##### `search-string-minimum-length`
 
-The `search-string-minimum-length` attribute is used to manage how many characters a user needs to typ in the `#input-filter` before the results start being filtered.
+The `search-string-minimum-length` attribute is used to manage how many characters a user needs to type in the `#input-filter` before the options in the dropdown start being filtered.
 
 ##### `selected-value`
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The project draws heavy inspiration from the jquery based [selectize.js](https:/
 
 The need for this project is that we want to use selectize.js however we need the over all app to be built in [Elm](https://elm-lang.org/). Elm needs to "own" the DOM and selectize is built in a way that's not compatible with that. 
 
-The goal for this project to achieve near feature parity with selectize using web components. The API will be different, so it will not be a drop in replacement but hopefully it will not be too hard to replace one with the other.
+The goal for this project to achieve near feature parity with selectize using web components. The API will be different, so it will not be a drop in replacement, but hopefully it will not be too hard to replace one with the other.
 
 ### Other Similar Projects
 
@@ -25,7 +25,7 @@ npm i much-select-elm
 
 ## Usage
 
-The npm package gives you the class `MuchSelect` (which inherits from `HTMLElement`), what you need to do is use it to define your own element.
+The npm package provides the class `MuchSelect` (which inherits from `HTMLElement`). To use it, the bare minimum to is do something like the following to define a custom element.
 
 ```javascript
 import MuchSelect from "@getdrip/much-select-elm";
@@ -93,17 +93,23 @@ npm run build
 
 #### Attributes
 
-##### `selected-value`
+##### `allow-custom-options`
 
-The `selected-value` attribute is used to set the value of the `<much-select>`.
+The `allow-custom-options` attribute will allow the user to add new options to the `<much-select>`, not just one of given ones. Of course, you will want to know when that's happened. You might be able to _just_ look at the value, but you might want to know when a custom option has been added too. For that there's the `customValueSelected` event.
+
 
 ##### `placeholder`
 
-The `placeholder` attribute is used to set the placeholder in the text input of the `<much-select>`. Just like in the `<input type="text">` it should only show up if the input is empty. 
+The `placeholder` attribute is used to set the placeholder in the text input of the `<much-select>`. Just like in the `<input type="text">` it should only show up if the input is empty.
 
-##### `allow-custom-options`
 
-The `allow-custom-options` attribute will allow the user to add new options to the `<much-select>`, not just one of given ones. Of course, you will want to know when that's happened. You might be able to _just_ look at the value, but you might want to know when a custom option has been added too. For that there's the `customValueSelected` event. 
+##### `search-string-minimum-length`
+
+The `search-string-minimum-length` attribute is used to manage how many characters a user needs to typ in the `#input-filter` before the results start being filtered.
+
+##### `selected-value`
+
+The `selected-value` attribute is used to set the value of the `<much-select>`.
 
 #### Options
 
@@ -119,11 +125,11 @@ This event fires if the `<much-select>` is cleared.
 
 ##### `optionSelected`
 
-This event fires if the `<much-select>` is in single or multi select mode but it's _mostly_ for multi select mode. It will just have the newly selected option in it (not all the selected options like the `valueChanged` event).
+This event fires if the `<much-select>` is in single or multi select mode, but it's _mostly_ for multi select mode. It will just have the newly selected option in it (not all the selected options like the `valueChanged` event).
 
 ##### `optionDeselected`
 
-This event fires if the `<much-select>` is in single or multi select mode but it's _mostly_ for multi select mode. It will just have the newly deselected option in it. This is kinda of the inverse of the `optionSelected` event.
+This event fires if the `<much-select>` is in single or multi select mode, but it's _mostly_ for multi select mode. It will just have the newly deselected option in it. This is kinda of the inverse of the `optionSelected` event.
 
 ##### `inputKeyUp`
 

--- a/public/attributes.html
+++ b/public/attributes.html
@@ -38,7 +38,7 @@
 
     <label>search-string-minimum-length
       <input type="range" min="0" max="10" value="3" id="search-string-minimum-length-range" />
-      <input type="text" readonly id="search-string-minimum-length-value" />
+      <input type="number" readonly maxlength="2" id="search-string-minimum-length-value" />
     </label>
 
     <much-select search-string-minimum-length="3">

--- a/public/attributes.html
+++ b/public/attributes.html
@@ -1,0 +1,446 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!--suppress HtmlUnknownTarget -->
+  <link rel="icon" href="./favicon.ico" type="image/x-icon" />
+  <title>Much Select - Attributes</title>
+  <link href="demo-styles.css" rel="stylesheet">
+</head>
+
+<body>
+
+<h1>Much-Select - Attributes</h1>
+
+<h2>Demo and Development Playground</h2>
+
+<nav>
+  <ol class="main-nav">
+    <li class="main-nav-item"><a href="index.html">Home</a></li>
+  </ol>
+</nav>
+
+
+<div class="container">
+  <div id="minimum-search-string-length">
+    <h3>The minimum serach string length</h3>
+    <p>
+      Using the <code>search-string-minimum-length</code> attribute sets the number of
+      characters that the user needs to type in the <code>#input-filter</code> before the
+      much-select begins to filter the search results.
+    </p>
+    <p>
+      The default value is 1. Meaning you have to type in at least 1 character
+      before it will start filtering.
+    </p>
+
+    <label>search-string-minimum-length
+      <input type="range" min="0" max="10" value="3" id="search-string-minimum-length-range" />
+      <input type="text" readonly id="search-string-minimum-length-value" />
+    </label>
+
+    <much-select search-string-minimum-length="3">
+      <!--suppress HtmlFormInputWithoutLabel -->
+      <select slot="select-input">
+        <option data-description="Chestnut Hill, MA">Conte Forum</option>
+        <option data-description="Clemson, SC">Littlejohn Coliseum</option>
+        <option data-description="Durham, NC">Cameron Indoor Stadium</option>
+        <option data-description="Tallahassee, FL">Donald L. Tucker Civic Center</option>
+        <option data-description="Atlanta, GA">Hank McCamish Pavilion</option>
+        <option data-description="Louisville, KY">KFC Yum! Center</option>
+        <option data-description="Coral Gables, FL">Watsco Center</option>
+        <option data-description="Chapel Hill, NC">Dean Smith Center</option>
+        <option data-description="Chapel Hill, NC">Carmichael Arena</option>
+        <option data-description="Raleigh, NC">PNC Arena</option>
+        <option data-description="Raleigh, NC">Reynolds Coliseum</option>
+        <option data-description="Notre Dame, IN">Edmund P. Joyce Center</option>
+        <option data-description="Pittsburgh, PA">Petersen Events Center</option>
+        <option data-description="Syracuse, NY">Carrier Dome</option>
+        <option data-description="Charlottesville, VA">John Paul Jones Arena</option>
+        <option data-description="Blacksburg, VA">Cassell Coliseum</option>
+        <option data-description="Winston-Salem, NC">Lawrence Joel Veterans Memorial Coliseum</option>
+        <option data-description="Guilderland, NY">SEFCU Arena</option>
+        <option data-description="Vestal, NY">Binghamton University Events Center</option>
+        <option data-description="Hartford, CT">Chase Arena</option>
+        <option data-description="Bangor, ME">Cross Insurance Center</option>
+        <option data-description="Durham, NH">Lundholm Gym</option>
+        <option data-description="Stony Brook, NY">Island Federal Credit Union Arena</option>
+        <option data-description="Newark, NJ">Wellness and Events Center</option>
+        <option data-description="Lowell, MA">Costello Athletic Center</option>
+        <option data-description="Lowell, MA">Tsongas Center</option>
+        <option data-description="Catonsville, MD">Chesapeake Employers Insurance Arena</option>
+        <option data-description="Burlington, VT">Patrick Gym</option>
+        <option data-description="Cincinnati, OH">Fifth Third Arena</option>
+        <option data-description="Greenville, NC">Williams Arena at Minges Coliseum</option>
+        <option data-description="Houston, TX">Fertitta Center</option>
+        <option data-description="Memphis, TN">FedExForum</option>
+        <option data-description="Memphis, TN">Elma Roane Fieldhouse</option>
+        <option data-description="University Park, TX">Moody Coliseum</option>
+        <option data-description="Tampa, FL">Yuengling Center</option>
+        <option data-description="Philadelphia, PA">Liacouras Center[a]</option>
+        <option data-description="New Orleans, LA">Devlin Fieldhouse</option>
+        <option data-description="Tulsa, OK">Reynolds Center</option>
+        <option data-description="Orlando, FL">Addition Financial Arena</option>
+        <option data-description="Wichita, KS">Charles Koch Arena[b]</option>
+        <option data-description="Louisville, KY">Freedom Hall</option>
+        <option data-description="Conway, AR">Farris Center</option>
+        <option data-description="Richmond, KY">Alumni Coliseum</option>
+        <option data-description="Fort Myers, FL">Alico Arena</option>
+        <option data-description="Jacksonville, FL">Swisher Gymnasium</option>
+        <option data-description="Jacksonville, AL">Pete Mathews Coliseum</option>
+        <option data-description="Kennesaw, GA">KSU Convocation Center</option>
+        <option data-description="Lynchburg, VA">Liberty Arena</option>
+        <option data-description="Florence, AL">Flowers Hall</option>
+        <option data-description="Nashville, TN">Allen Arena</option>
+        <option data-description="Jacksonville, FL">UNF Arena</option>
+        <option data-description="DeLand, FL">Edmunds Center</option>
+        <option data-description="Davidson, NC">John M. Belk Arena</option>
+        <option data-description="Dayton, OH">University of Dayton Arena</option>
+        <option data-description="Pittsburgh, PA">UPMC Cooper Fieldhouse</option>
+        <option data-description="Bronx, NY">Rose Hill Gymnasium</option>
+        <option data-description="Fairfax, VA">EagleBank Arena</option>
+        <option data-description="Washington, DC">Charles E. Smith Center</option>
+        <option data-description="Philadelphia, PA">Tom Gola Arena</option>
+        <option data-description="Amherst, MA">Mullins Center</option>
+        <option data-description="Kingston, RI">Ryan Center</option>
+        <option data-description="Richmond, VA">Robins Center</option>
+        <option data-description="St. Bonaventure, NY">Reilly Center</option>
+        <option data-description="Philadelphia, PA">Hagan Arena</option>
+        <option data-description="St. Louis, MO">Chaifetz Arena</option>
+        <option data-description="Richmond, VA">Siegel Center</option>
+        <option data-description="Waco, TX">Ferrell Center</option>
+        <option data-description="Ames, IA">Hilton Coliseum</option>
+        <option data-description="Lawrence, KS">Allen Fieldhouse</option>
+        <option data-description="Manhattan, KS">Bramlage Coliseum</option>
+        <option data-description="Norman, OK">Lloyd Noble Center</option>
+        <option data-description="Stillwater, OK">Gallagher-Iba Arena</option>
+        <option data-description="Austin, TX">Frank Erwin Center</option>
+        <option data-description="Fort Worth, TX">Schollmaier Arena</option>
+        <option data-description="Lubbock, TX">United Supermarkets Arena</option>
+        <option data-description="Morgantown, WV">WVU Coliseum</option>
+        <option data-description="Indianapolis, IN">Hinkle Fieldhouse</option>
+        <option data-description="Omaha, NE">CHI Health Center Omaha</option>
+        <option data-description="Omaha, NE">D. J. Sokol Arena</option>
+        <option data-description="Chicago, IL">Wintrust Arena[c]</option>
+        <option data-description="Washington, DC">Capital One Arena</option>
+        <option data-description="Washington, DC">McDonough Gymnasium</option>
+        <option data-description="Milwaukee, WI">Fiserv Forum</option>
+        <option data-description="Milwaukee, WI">Al McGuire Center</option>
+        <option data-description="Providence, RI">Dunkin' Donuts Center</option>
+        <option data-description="Providence, RI">Alumni Hall</option>
+        <option data-description="Newark, NJ">Prudential Center</option>
+        <option data-description="South Orange, NJ">Walsh Gymnasium</option>
+        <option data-description="New York, NY">Madison Square Garden[d]</option>
+        <option data-description="Queens, NY">Carnesecca Arena</option>
+        <option data-description="Storrs, CT">Harry A. Gampel Pavilion[e]</option>
+        <option data-description="Villanova, PA">Finneran Pavilion[f]</option>
+        <option data-description="Cincinnati, OH">Cintas Center</option>
+        <option data-description="Cheney, WA">Reese Court</option>
+        <option data-description="Moscow, ID">Idaho Central Credit Union Arena</option>
+        <option data-description="Pocatello, ID">Holt Arena</option>
+        <option data-description="Pocatello, ID">Reed Gym</option>
+        <option data-description="Missoula, MT">Dahlberg Arena</option>
+        <option data-description="Bozeman, MT">Brick Breeden Fieldhouse</option>
+        <option data-description="Flagstaff, AZ">Walkup Skydome</option>
+        <option data-description="Greeley, CO">Bank of Colorado Arena</option>
+        <option data-description="Portland, OR">Viking Pavilion</option>
+        <option data-description="Sacramento, CA">Hornets Nest</option>
+        <option data-description="Cedar City, UT">America First Event Center</option>
+        <option data-description="Ogden, UT">Dee Events Center</option>
+        <option data-description="Buies Creek, NC">John W. Pope, Jr. Convocation Center</option>
+        <option data-description="North Charleston, SC">Buccaneer Field House</option>
+        <option data-description="Boiling Springs, NC">Paul Porter Arena</option>
+        <option data-description="Hampton, VA">Hampton Convocation Center</option>
+        <option data-description="High Point, NC">Nido & Mariana Qubein Arena and Conference Center</option>
+        <option data-description="Farmville, VA">Willett Hall</option>
+        <option data-description="Greensboro, NC">Corbett Sports Center</option>
+        <option data-description="Clinton, SC">Templeton Physical Education Center</option>
+        <option data-description="Radford, VA">Dedmon Center</option>
+        <option data-description="Asheville, NC">Kimmel Arena</option>
+        <option data-description="Spartanburg, SC">G. B. Hodge Center</option>
+        <option data-description="Rock Hill, SC">Winthrop Coliseum</option>
+        <option data-description="Champaign, IL">State Farm Center</option>
+        <option data-description="Bloomington, IN">Simon Skjodt Assembly Hall</option>
+        <option data-description="Iowa City, IA">Carver–Hawkeye Arena</option>
+        <option data-description="College Park, MD">Xfinity Center</option>
+        <option data-description="Ann Arbor, MI">Crisler Center</option>
+        <option data-description="East Lansing, MI">Breslin Student Events Center</option>
+        <option data-description="Minneapolis, MN">Williams Arena</option>
+        <option data-description="Lincoln, NE">Pinnacle Bank Arena</option>
+        <option data-description="Evanston, IL">Welsh–Ryan Arena</option>
+        <option data-description="Columbus, OH">Value City Arena</option>
+        <option data-description="University Park, PA">Bryce Jordan Center</option>
+        <option data-description="West Lafayette, IN">Mackey Arena</option>
+        <option data-description="Piscataway, NJ">Jersey Mike's Arena</option>
+        <option data-description="Madison, WI">Kohl Center</option>
+        <option data-description="San Luis Obispo, CA">Robert A. Mott Athletics Center</option>
+        <option data-description="Bakersfield, CA">Icardo Center</option>
+        <option data-description="Fullerton, CA">Titan Gym</option>
+        <option data-description="Northridge, CA">Matadome</option>
+        <option data-description="Honolulu, HI">Stan Sheriff Center</option>
+        <option data-description="Long Beach, CA">Walter Pyramid</option>
+        <option data-description="Davis, CA">The Pavilion at ARC</option>
+        <option data-description="Irvine, CA">Bren Events Center</option>
+        <option data-description="Riverside, CA">Student Recreation Center Arena</option>
+        <option data-description="La Jolla, CA">RIMAC Arena</option>
+        <option data-description="Santa Barbara, CA">UC Santa Barbara Events Center</option>
+        <option data-description="Charleston, SC">TD Arena</option>
+        <option data-description="Newark, DE">Bob Carpenter Center</option>
+        <option data-description="Philadelphia, PA">Daskalakis Athletic Center</option>
+        <option data-description="Elon, NC">Schar Center</option>
+        <option data-description="Hempstead, NY">Mack Sports Complex</option>
+        <option data-description="Harrisonburg, VA">Atlantic Union Bank Center</option>
+        <option data-description="Boston, MA">Matthews Arena</option>
+        <option data-description="Boston, MA">Cabot Center</option>
+        <option data-description="Towson, MD">SECU Arena</option>
+        <option data-description="Wilmington, NC">Trask Coliseum</option>
+        <option data-description="Williamsburg, VA">Kaplan Arena</option>
+        <option data-description="Charlotte, NC">Dale F. Halton Arena</option>
+        <option data-description="Miami, FL">Ocean Bank Convocation Center</option>
+        <option data-description="Boca Raton, FL">FAU Arena</option>
+        <option data-description="Ruston, LA">Thomas Assembly Center</option>
+        <option data-description="Huntington, WV">Cam Henderson Center</option>
+        <option data-description="Murfreesboro, TN">Murphy Center</option>
+        <option data-description="Denton, TX">UNT Coliseum</option>
+        <option data-description="Norfolk, VA">Chartway Arena</option>
+        <option data-description="Houston, TX">Tudor Fieldhouse</option>
+        <option data-description="Hattiesburg, MS">Reed Green Coliseum</option>
+        <option data-description="Birmingham, AL">Bartow Arena</option>
+        <option data-description="El Paso, TX">Don Haskins Center</option>
+        <option data-description="San Antonio, TX">Convocation Center</option>
+        <option data-description="Bowling Green, KY">E. A. Diddle Arena</option>
+        <option data-description="Cleveland, OH">Wolstein Center</option>
+        <option data-description="Detroit, MI">Calihan Hall</option>
+        <option data-description="Ashwaubenon, WI">Resch Center</option>
+        <option data-description="Green Bay, WI">Kress Events Center</option>
+        <option data-description="Indianapolis, IN">Indiana Farmers Coliseum</option>
+        <option data-description="Indianapolis, IN">The Jungle</option>
+        <option data-description="Milwaukee, WI">UW–Milwaukee Panther Arena</option>
+        <option data-description="Milwaukee, WI">Klotsche Center</option>
+        <option data-description="Highland Heights, KY">BB&T Arena</option>
+        <option data-description="Rochester, MI">Athletics Center O'rena</option>
+        <option data-description="Fort Wayne, IN">Hilliard Gates Sports Center</option>
+        <option data-description="Moon Township, PA">UPMC Events Center</option>
+        <option data-description="Chicago, IL">Credit Union 1 Arena</option>
+        <option data-description="Fairborn, OH">Nutter Center</option>
+        <option data-description="Youngstown, OH">Beeghly Center</option>
+        <option data-description="Providence, RI">Pizzitola Sports Center</option>
+        <option data-description="New York, NY">Levien Gymnasium</option>
+        <option data-description="Ithaca, NY">Newman Arena</option>
+        <option data-description="Hanover, NH">Leede Arena</option>
+        <option data-description="Allston, MA">Lavietes Pavilion</option>
+        <option data-description="Philadelphia, PA">Palestra</option>
+        <option data-description="Princeton, NJ">Jadwin Gymnasium</option>
+        <option data-description="New Haven, CT">John J. Lee Amphitheater</option>
+        <option data-description="Buffalo, NY">Koessler Athletic Center</option>
+        <option data-description="Bridgeport, CT">Webster Bank Arena</option>
+        <option data-description="New Rochelle, NY">Hynes Athletic Center</option>
+        <option data-description="Bronx, NY">Draddy Gymnasium</option>
+        <option data-description="Poughkeepsie, NY">McCann Arena</option>
+        <option data-description="West Long Branch, NJ">OceanFirst Bank Center</option>
+        <option data-description="Lewiston, NY">Gallagher Center</option>
+        <option data-description="Hamden, CT">People's United Center</option>
+        <option data-description="Lawrenceville, NJ">Alumni Gymnasium</option>
+        <option data-description="Albany, NY">Times Union Center</option>
+        <option data-description="Loudonville, NY">Alumni Recreation Center</option>
+        <option data-description="Jersey City, NJ">Yanitelli Center</option>
+        <option data-description="Akron, OH">James A. Rhodes Arena</option>
+        <option data-description="Muncie, IN">Worthen Arena</option>
+        <option data-description="Bowling Green, OH">Stroh Center</option>
+        <option data-description="Amherst, NY">Alumni Arena</option>
+        <option data-description="Mount Pleasant, MI">McGuirk Arena</option>
+        <option data-description="Ypsilanti, MI">George Gervin GameAbove Center</option>
+        <option data-description="Kent, OH">Memorial Athletic and Convocation Center</option>
+        <option data-description="Oxford, OH">Millett Hall</option>
+        <option data-description="DeKalb, IL">Convocation Center</option>
+        <option data-description="Athens, OH">Convocation Center</option>
+        <option data-description="Toledo, OH">Savage Arena</option>
+        <option data-description="Kalamazoo, MI">University Arena</option>
+        <option data-description="Baltimore, MD">Physical Education Complex</option>
+        <option data-description="Dover, DE">Memorial Hall</option>
+        <option data-description="Washington, DC">Burr Gymnasium</option>
+        <option data-description="Princess Anne, MD">Hytche Athletic Center</option>
+        <option data-description="Baltimore, MD">Talmadge L. Hill Field House</option>
+        <option data-description="Norfolk, VA">Joseph G. Echols Memorial Hall</option>
+        <option data-description="Durham, NC">McDougald–McLendon Arena</option>
+        <option data-description="Orangeburg, SC">SHM Memorial Center</option>
+        <option data-description="Peoria, IL">Carver Arena</option>
+        <option data-description="Peoria, IL">Renaissance Coliseum</option>
+        <option data-description="Des Moines, IA">Knapp Center</option>
+        <option data-description="Evansville, IN">Ford Center</option>
+        <option data-description="Evansville, IN">Meeks Family Fieldhouse</option>
+        <option data-description="Normal, IL">Redbird Arena</option>
+        <option data-description="Terre Haute, IN">Hulman Center</option>
+        <option data-description="Chicago, IL">Joseph J. Gentile Arena</option>
+        <option data-description="Springfield, MO">JQH Arena</option>
+        <option data-description="Cedar Falls, IA">McLeod Center</option>
+        <option data-description="Carbondale, IL">Banterra Center</option>
+        <option data-description="Valparaiso, IN">Athletics–Recreation Center</option>
+        <option data-description="Colorado Springs, CO">Cadet Field House</option>
+        <option data-description="Boise, ID">ExtraMile Arena</option>
+        <option data-description="Fort Collins, CO">Moby Arena</option>
+        <option data-description="Fresno, CA">Save Mart Center</option>
+        <option data-description="Reno, NV">Lawlor Events Center</option>
+        <option data-description="Albuquerque, NM">The Pit</option>
+        <option data-description="San Diego, CA">Viejas Arena</option>
+        <option data-description="San Jose, CA">Provident Credit Union Event Center</option>
+        <option data-description="Paradise, NV">Thomas & Mack Center</option>
+        <option data-description="Paradise, NV">Cox Pavilion</option>
+        <option data-description="Logan, UT">Smith Spectrum</option>
+        <option data-description="Laramie, WY">Arena-Auditorium</option>
+        <option data-description="Smithfield, RI">Chace Athletic Center</option>
+        <option data-description="New Britain, CT">William H. Detrick Gymnasium</option>
+        <option data-description="Hackensack, NJ">Rothman Center</option>
+        <option data-description="Brooklyn, NY">Steinberg Wellness Center</option>
+        <option data-description="North Andover, MA">Hammel Court</option>
+        <option data-description="Emmitsburg, MD">Knott Arena</option>
+        <option data-description="Fairfield, CT">William H. Pitt Center</option>
+        <option data-description="Brooklyn, NY">Generoso Pope Athletic Complex</option>
+        <option data-description="Loretto, PA">DeGol Arena</option>
+        <option data-description="Staten Island, NY">Spiro Sports Center</option>
+        <option data-description="Clarksville, TN">Dunn Center</option>
+        <option data-description="Nashville, TN">Curb Event Center</option>
+        <option data-description="Charleston, IL">Lantz Arena</option>
+        <option data-description="Morehead, KY">Ellis Johnson Arena</option>
+        <option data-description="Murray, KY">CFSB Center</option>
+        <option data-description="Cape Girardeau, MO">Show Me Center</option>
+        <option data-description="Edwardsville, IL">Vadalabene Center</option>
+        <option data-description="Martin, TN">Kathleen and Tom Elam Center</option>
+        <option data-description="Nashville, TN">Gentry Complex</option>
+        <option data-description="Cookeville, TN">Eblen Center</option>
+        <option data-description="Tucson, AZ">McKale Center</option>
+        <option data-description="Tempe, AZ">Desert Financial Arena</option>
+        <option data-description="Berkeley, CA">Haas Pavilion</option>
+        <option data-description="Boulder, CO">CU Events Center</option>
+        <option data-description="Eugene, OR">Matthew Knight Arena</option>
+        <option data-description="Corvallis, OR">Gill Coliseum</option>
+        <option data-description="Stanford, CA">Maples Pavilion</option>
+        <option data-description="Los Angeles, CA">Pauley Pavilion</option>
+        <option data-description="Los Angeles, CA">Galen Center</option>
+        <option data-description="Salt Lake City, UT">Jon M. Huntsman Center</option>
+        <option data-description="Seattle, WA">Alaska Airlines Arena at Hec Edmundson Pavilion</option>
+        <option data-description="Pullman, WA">Beasley Coliseum</option>
+        <option data-description="Washington, DC">Bender Arena</option>
+        <option data-description="West Point, NY">Christl Arena</option>
+        <option data-description="Boston, MA">Case Gym</option>
+        <option data-description="Lewisburg, PA">Sojka Pavilion</option>
+        <option data-description="Hamilton, NY">Cotterell Court</option>
+        <option data-description="Worcester, MA">Hart Center</option>
+        <option data-description="Easton, PA">Kirby Sports Center</option>
+        <option data-description="Bethlehem, PA">Stabler Arena</option>
+        <option data-description="Baltimore, MD">Reitz Arena</option>
+        <option data-description="Annapolis, MD">Alumni Hall</option>
+        <option data-description="Tuscaloosa, AL">Coleman Coliseum</option>
+        <option data-description="Fayetteville, AR">Bud Walton Arena</option>
+        <option data-description="Auburn, AL">Neville Arena</option>
+        <option data-description="Gainesville, FL">O'Connell Center</option>
+        <option data-description="Athens, GA">Stegeman Coliseum</option>
+        <option data-description="Lexington, KY">Rupp Arena</option>
+        <option data-description="Lexington, KY">Memorial Coliseum</option>
+        <option data-description="Baton Rouge, LA">Pete Maravich Assembly Center</option>
+        <option data-description="Oxford, MS">The Sandy and John Black Pavilion at Ole Miss</option>
+        <option data-description="Starkville, MS">Humphrey Coliseum</option>
+        <option data-description="Columbia, MO">Mizzou Arena</option>
+        <option data-description="Columbia, SC">Colonial Life Arena</option>
+        <option data-description="Knoxville, TN">Thompson–Boling Arena</option>
+        <option data-description="College Station, TX">Reed Arena</option>
+        <option data-description="Nashville, TN">Memorial Gymnasium</option>
+        <option data-description="Chattanooga, TN">McKenzie Arena</option>
+        <option data-description="Charleston, SC">McAlister Field House</option>
+        <option data-description="Johnson City, TN">Freedom Hall Civic Center</option>
+        <option data-description="Greenville, SC">Timmons Arena</option>
+        <option data-description="Macon, GA">Hawkins Arena</option>
+        <option data-description="Homewood, AL">Pete Hanna Center</option>
+        <option data-description="Greensboro, NC">Greensboro Coliseum</option>
+        <option data-description="Lexington, VA">Cameron Hall</option>
+        <option data-description="Cullowhee, NC">Ramsey Center</option>
+        <option data-description="Spartanburg, SC">Jerry Richardson Indoor Stadium</option>
+        <option data-description="Houston, TX">Sharp Gymnasium</option>
+        <option data-description="San Antonio, TX">McDermott Center</option>
+        <option data-description="Lake Charles, LA">The Legacy Center</option>
+        <option data-description="New Orleans, LA">Lakefront Arena</option>
+        <option data-description="Thibodaux, LA">Stopher Gymnasium</option>
+        <option data-description="Natchitoches, LA">Prather Coliseum</option>
+        <option data-description="Hammond, LA">University Center</option>
+        <option data-description="Corpus Christi, TX">American Bank Center Arena[h]</option>
+        <option data-description="Denver, CO">Magness Arena</option>
+        <option data-description="Kansas City, MO">Swinney Recreation Center</option>
+        <option data-description="Grand Forks, ND">Betty Engelstad Sioux Center</option>
+        <option data-description="Fargo, ND">Scheels Center</option>
+        <option data-description="Omaha, NE">Baxter Arena</option>
+        <option data-description="Tulsa, OK">Mabee Center</option>
+        <option data-description="Saint Paul, MN">Schoenecker Arena</option>
+        <option data-description="Vermillion, SD">Sanford Coyote Sports Center</option>
+        <option data-description="Brookings, SD">Frost Arena</option>
+        <option data-description="Macomb, IL">Western Hall</option>
+        <option data-description="Boone, NC">George M. Holmes Convocation Center</option>
+        <option data-description="Jonesboro, AR">First National Bank Arena</option>
+        <option data-description="Conway, SC">HTC Center</option>
+        <option data-description="Statesboro, GA">Hanner Fieldhouse</option>
+        <option data-description="Atlanta, GA">GSU Sports Arena</option>
+        <option data-description="Little Rock, AR">Jack Stephens Center</option>
+        <option data-description="Lafayette, LA">Cajundome</option>
+        <option data-description="Monroe, LA">Fant–Ewing Coliseum</option>
+        <option data-description="Mobile, AL">Mitchell Center</option>
+        <option data-description="San Marcos, TX">Strahan Arena</option>
+        <option data-description="Troy, AL">Trojan Arena</option>
+        <option data-description="Arlington, TX">College Park Center</option>
+        <option data-description="Normal, AL">Elmore Gymnasium</option>
+        <option data-description="Montgomery, AL">Dunn–Oliver Acadome</option>
+        <option data-description="Lorman, MS">Davey Whitney Complex</option>
+        <option data-description="Pine Bluff, AR">K. L. Johnson Complex</option>
+        <option data-description="Daytona, FL">Moore Gymnasium</option>
+        <option data-description="Tallahassee, FL">Al Lawson Center</option>
+        <option data-description="Grambling, LA">Fredrick C. Hobdy Assembly Center</option>
+        <option data-description="Jackson, MS">Williams Assembly Center</option>
+        <option data-description="Itta Bena, MS">Harrison HPER Complex</option>
+        <option data-description="Prairie View, TX">William J. Nicks Building</option>
+        <option data-description="Baton Rouge, LA">F. G. Clark Center</option>
+        <option data-description="Houston, TX">Health and Physical Education Arena</option>
+        <option data-description="Provo, UT">Marriott Center</option>
+        <option data-description="Spokane, WA">McCarthey Athletic Center</option>
+        <option data-description="Los Angeles, CA">Gersten Pavilion</option>
+        <option data-description="Stockton, CA">Alex G. Spanos Center</option>
+        <option data-description="Malibu, CA">Firestone Fieldhouse</option>
+        <option data-description="Portland, OR">Chiles Center</option>
+        <option data-description="Moraga, CA">University Credit Union Pavilion</option>
+        <option data-description="San Diego, CA">Jenny Craig Pavilion</option>
+        <option data-description="San Francisco, CA">The Sobrato Center</option>
+        <option data-description="Santa Clara, CA">Leavey Center</option>
+        <option data-description="Abilene, TX">Moody Coliseum</option>
+        <option data-description="Riverside, CA">CBU Events Center</option>
+        <option data-description="Chicago, IL">Emil and Patricia Jones Convocation Center</option>
+        <option data-description="St. George, UT">Burns Arena</option>
+        <option data-description="Phoenix, AZ">GCU Arena</option>
+        <option data-description="Beaumont, TX">Montagne Center</option>
+        <option data-description="Las Cruces, NM">Pan American Center</option>
+        <option data-description="Huntsville, TX">Bernard Johnson Coliseum</option>
+        <option data-description="Seattle, WA">Redhawk Center</option>
+        <option data-description="Nacogdoches, TX">William R. Johnson Coliseum</option>
+        <option data-description="Stephenville, TX">Wisdom Gymnasium</option>
+        <option data-description="Orem, UT">UCCU Center</option>
+        <option data-description="Edinburg, TX">UTRGV Fieldhouse</option>
+      </select>
+    </much-select>
+    <script>
+      window.addEventListener("load", () => {
+        document
+          .querySelector("#search-string-minimum-length-range")
+          .addEventListener("change", (evt) => {
+            document
+              .querySelector("#minimum-search-string-length much-select")
+              .setAttribute("search-string-minimum-length", evt.target.value);
+            document
+              .querySelector("#search-string-minimum-length-value")
+              .setAttribute("value", evt.target.value);
+          });
+      });
+    </script>
+  </div>
+</div>
+
+<script src="./index.js" type="module"></script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,7 @@
 
 <nav>
   <ol class="main-nav">
+    <li class="main-nav-item"><a href="attributes.html">Attributes</a></li>
     <li class="main-nav-item"><a href="initial-value.html">Initial Value</a></li>
     <li class="main-nav-item"><a href="option-api.html">Option API</a></li>
     <li class="main-nav-item"><a href="events.html">Events</a></li>

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -668,10 +668,6 @@ clearAllSelectedOption model =
 
 updateModelWithSearchStringChanges : PositiveInt -> String -> List Option -> Model -> Model
 updateModelWithSearchStringChanges maxNumberOfDropdownItems searchString options model =
-    let
-        optionsUpdatedWithSearchString =
-            OptionSearcher.updateOptions model.selectionMode model.customOptionHint searchString options
-    in
     if String.length searchString == 0 then
         -- the search string is empty, let's make sure everything get cleared out of the model.
         let
@@ -703,6 +699,9 @@ updateModelWithSearchStringChanges maxNumberOfDropdownItems searchString options
         -- We have a search string and it's over the minimum length for filter. Let's update the model and filter the
         -- the options.
         let
+            optionsUpdatedWithSearchString =
+                OptionSearcher.updateOptions model.selectionMode model.customOptionHint searchString options
+
             optionsSortedByTotalScore =
                 optionsUpdatedWithSearchString
                     |> Option.sortOptionsByTotalScore

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -83,6 +83,7 @@ import Ports
         , removeOptionsReceiver
         , requestAllOptionsReceiver
         , scrollDropdownToElement
+        , searchStringMinimumLengthChangedReceiver
         , selectOptionReceiver
         , selectedItemStaysInPlaceChangedReceiver
         , valueCasingDimensionsChangedReceiver
@@ -127,6 +128,7 @@ type Msg
     | DisabledAttributeChanged Bool
     | MultiSelectAttributeChanged Bool
     | MultiSelectSingleItemRemovalAttributeChanged Bool
+    | SearchStringMinimumLengthAttributeChanged Int
     | SelectedItemStaysInPlaceChanged Bool
     | SelectHighlightedOption
     | DeleteInputForSingleSelect
@@ -153,6 +155,7 @@ type alias Model =
     , optionsForTheDropdown : List Option
     , showDropdown : Bool
     , searchString : String
+    , minimumSearchStringLength : PositiveInt
     , rightSlot : RightSlot
     , maxDropdownItems : PositiveInt
     , disabled : Bool
@@ -497,6 +500,9 @@ update msg model =
             , Cmd.batch [ muchSelectIsReady (), cmd ]
             )
 
+        SearchStringMinimumLengthAttributeChanged searchStringMinimumLength ->
+            ( { model | minimumSearchStringLength = PositiveInt.new searchStringMinimumLength }, Cmd.none )
+
         SelectHighlightedOption ->
             let
                 options =
@@ -683,7 +689,7 @@ updateModelWithSearchStringChanges maxNumberOfDropdownItems searchString options
 
     else if String.length searchString <= 1 then
         -- We have a search string but it's below are minimum for filtering. This means we still want to update the
-        -- serach string it self in the model but we don't need to do anything with the options
+        -- search string it self in the model but we don't need to do anything with the options
         let
             updatedOptions =
                 OptionSearcher.updateOptions model.selectionMode model.customOptionHint "" options
@@ -1638,6 +1644,7 @@ init flags =
                 optionsWithInitialValueSelected
       , showDropdown = False
       , searchString = ""
+      , minimumSearchStringLength = PositiveInt.new 0
       , rightSlot =
             if flags.loading then
                 ShowLoadingIndicator
@@ -1699,6 +1706,7 @@ subscriptions _ =
         , deselectOptionReceiver DeselectOption
         , multiSelectChangedReceiver MultiSelectAttributeChanged
         , multiSelectSingleItemRemovalChangedReceiver MultiSelectSingleItemRemovalAttributeChanged
+        , searchStringMinimumLengthChangedReceiver SearchStringMinimumLengthAttributeChanged
         , requestAllOptionsReceiver (\() -> RequestAllOptions)
         ]
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1561,6 +1561,7 @@ type alias Flags =
     , disabled : Bool
     , allowCustomOptions : Bool
     , selectedItemStaysInPlace : Bool
+    , searchStringMinimumLength : Int
     }
 
 
@@ -1666,7 +1667,9 @@ init flags =
                 optionsWithInitialValueSelected
       , showDropdown = False
       , searchString = ""
-      , searchStringMinimumLength = PositiveInt.new 0
+      , searchStringMinimumLength =
+            Maybe.withDefault (PositiveInt.new 2)
+                (PositiveInt.maybeNew flags.searchStringMinimumLength)
       , rightSlot =
             if flags.loading then
                 ShowLoadingIndicator

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -155,7 +155,7 @@ type alias Model =
     , optionsForTheDropdown : List Option
     , showDropdown : Bool
     , searchString : String
-    , minimumSearchStringLength : PositiveInt
+    , searchStringMinimumLength : PositiveInt
     , rightSlot : RightSlot
     , maxDropdownItems : PositiveInt
     , disabled : Bool
@@ -202,7 +202,7 @@ update msg model =
                 -- clear out the search string
                 updatedModel =
                     updateModelWithSearchStringChanges
-                        model.minimumSearchStringLength
+                        model.searchStringMinimumLength
                         model.maxDropdownItems
                         ""
                         optionsWithoutUnselectedCustomOptions
@@ -260,7 +260,7 @@ update msg model =
             in
             case model.selectionMode of
                 SingleSelect _ _ ->
-                    ( updateModelWithSearchStringChanges model.minimumSearchStringLength model.maxDropdownItems "" options model
+                    ( updateModelWithSearchStringChanges model.searchStringMinimumLength model.maxDropdownItems "" options model
                     , Cmd.batch
                         [ makeCommandMessagesWhenValuesChanges options (Just optionValue)
                         , blurInput ()
@@ -268,7 +268,7 @@ update msg model =
                     )
 
                 MultiSelect _ _ ->
-                    ( updateModelWithSearchStringChanges model.minimumSearchStringLength model.maxDropdownItems "" options model
+                    ( updateModelWithSearchStringChanges model.searchStringMinimumLength model.maxDropdownItems "" options model
                     , Cmd.batch
                         [ makeCommandMessagesWhenValuesChanges options (Just optionValue)
                         , focusInput ()
@@ -276,7 +276,7 @@ update msg model =
                     )
 
         SearchInputOnInput searchString ->
-            ( updateModelWithSearchStringChanges model.minimumSearchStringLength model.maxDropdownItems searchString model.options model
+            ( updateModelWithSearchStringChanges model.searchStringMinimumLength model.maxDropdownItems searchString model.options model
             , inputKeyUp searchString
             )
 
@@ -390,7 +390,7 @@ update msg model =
                                     selectSingleOptionInList optionValue model.options
                     in
                     ( updateModelWithSearchStringChanges
-                        model.minimumSearchStringLength
+                        model.searchStringMinimumLength
                         model.maxDropdownItems
                         ""
                         options
@@ -507,7 +507,7 @@ update msg model =
             )
 
         SearchStringMinimumLengthAttributeChanged searchStringMinimumLength ->
-            ( { model | minimumSearchStringLength = PositiveInt.new searchStringMinimumLength }, Cmd.none )
+            ( { model | searchStringMinimumLength = PositiveInt.new searchStringMinimumLength }, Cmd.none )
 
         SelectHighlightedOption ->
             let
@@ -517,7 +517,7 @@ update msg model =
             case model.selectionMode of
                 SingleSelect _ _ ->
                     ( updateModelWithSearchStringChanges
-                        model.minimumSearchStringLength
+                        model.searchStringMinimumLength
                         model.maxDropdownItems
                         ""
                         options
@@ -531,7 +531,7 @@ update msg model =
 
                 MultiSelect _ _ ->
                     ( updateModelWithSearchStringChanges
-                        model.minimumSearchStringLength
+                        model.searchStringMinimumLength
                         model.maxDropdownItems
                         ""
                         options
@@ -557,7 +557,7 @@ update msg model =
                     ( model, Cmd.none )
 
         EscapeKeyInInputFilter ->
-            ( updateModelWithSearchStringChanges model.minimumSearchStringLength
+            ( updateModelWithSearchStringChanges model.searchStringMinimumLength
                 model.maxDropdownItems
                 ""
                 model.options
@@ -1666,7 +1666,7 @@ init flags =
                 optionsWithInitialValueSelected
       , showDropdown = False
       , searchString = ""
-      , minimumSearchStringLength = PositiveInt.new 0
+      , searchStringMinimumLength = PositiveInt.new 0
       , rightSlot =
             if flags.loading then
                 ShowLoadingIndicator

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -24,6 +24,7 @@ port module Ports exposing
     , removeOptionsReceiver
     , requestAllOptionsReceiver
     , scrollDropdownToElement
+    , searchStringMinimumLengthChangedReceiver
     , selectOptionReceiver
     , selectedItemStaysInPlaceChangedReceiver
     , valueCasingDimensionsChangedReceiver
@@ -143,6 +144,9 @@ port multiSelectChangedReceiver : (Bool -> msg) -> Sub msg
 
 
 port multiSelectSingleItemRemovalChangedReceiver : (Bool -> msg) -> Sub msg
+
+
+port searchStringMinimumLengthChangedReceiver : (Int -> msg) -> Sub msg
 
 
 port selectedItemStaysInPlaceChangedReceiver : (Bool -> msg) -> Sub msg

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -198,6 +198,15 @@ class MuchSelect extends HTMLElement {
     this._maxDropdownItems = 10000;
 
     /**
+     * As the user types to filter the search results, what is the minium number of character they need to type before
+     *  the options are filtered.
+     *
+     * @type {number}
+     * @private
+     */
+    this._searchStringMinimumLength = 1;
+
+    /**
      * @type {boolean}
      * @private
      */
@@ -324,6 +333,7 @@ class MuchSelect extends HTMLElement {
       "multi-select",
       "multi-select-single-item-removal",
       "placeholder",
+      "search-string-minimum-length",
       "selected-option-goes-to-top",
       "selected-value",
       "selected-value-encoding",
@@ -365,6 +375,10 @@ class MuchSelect extends HTMLElement {
       if (oldValue !== newValue) {
         this.updateDimensions();
         this.placeholder = newValue;
+      }
+    } else if (name === "search-string-minimum-length") {
+      if (oldValue !== newValue) {
+        this.searchStringMinimumLength = newValue;
       }
     } else if (name === "selected-option-goes-to-top") {
       if (oldValue !== newValue) {
@@ -1127,6 +1141,55 @@ class MuchSelect extends HTMLElement {
     // noinspection JSUnresolvedVariable
     this.appPromise.then((app) =>
       app.ports.maxDropdownItemsChangedReceiver.send(this._maxDropdownItems)
+    );
+  }
+
+  /**
+   * Search String Minimum Length getter.
+   *
+   * @returns {number}
+   */
+  get searchStringMinimumLength() {
+    return this._searchStringMinimumLength;
+  }
+
+  /**
+   * Search String Minimum Length setter
+   *
+   * @param value {string|number}
+   */
+  set searchStringMinimumLength(value) {
+    if (value === "false") {
+      this._searchStringMinimumLength = 0;
+    } else if (value === "") {
+      this._searchStringMinimumLength = 0;
+    } else if (Number.isInteger(value)) {
+      if (value >= 0) {
+        this._searchStringMinimumLength = value;
+      } else {
+        this._searchStringMinimumLength = 0;
+      }
+    } else if (typeof value === "string") {
+      const intVal = parseInt(value, 10);
+      if (intVal >= 0) {
+        this._searchStringMinimumLength = intVal;
+      } else {
+        this._searchStringMinimumLength = 0;
+      }
+    }
+
+    if (!this.eventsOnlyMode) {
+      this.setAttribute(
+        "search-string-minimum-length",
+        `${this._searchStringMinimumLength}`
+      );
+    }
+
+    // noinspection JSUnresolvedVariable
+    this.appPromise.then((app) =>
+      app.ports.searchStringMinimumLengthChangedReceiver.send(
+        this._searchStringMinimumLength
+      )
     );
   }
 

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -204,7 +204,7 @@ class MuchSelect extends HTMLElement {
      * @type {number}
      * @private
      */
-    this._searchStringMinimumLength = 1;
+    this._searchStringMinimumLength = 2;
 
     /**
      * @type {boolean}
@@ -780,6 +780,15 @@ class MuchSelect extends HTMLElement {
       flags.size = this.getAttribute("size").trim();
     } else {
       flags.size = "";
+    }
+
+    if (this.hasAttribute("search-string-minimum-length")) {
+      flags.searchStringMinimumLength = parseInt(
+        this.getAttribute("search-string-minimum-length").trim(),
+        10
+      );
+    } else {
+      flags.searchStringMinimumLength = this.searchStringMinimumLength;
     }
 
     flags.disabled = this.disabled;

--- a/tests/Attributes/search-string-minimum-length.test.html
+++ b/tests/Attributes/search-string-minimum-length.test.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<body>
+<script type="module">
+  import { runTests } from "@web/test-runner-mocha";
+  import { expect } from "@esm-bundle/chai";
+  import { html, fixture } from "@open-wc/testing";
+
+  import MuchSelect from "../../dist/much-select-debug.js";
+
+  if (!customElements.get("much-select")) {
+    // Putting guard rails around this because browsers do not like
+    //  having the same custom element defined more than once.
+    window.customElements.define("much-select", MuchSelect);
+  }
+
+  runTests(() => {
+    describe("Attributes", () => {
+      describe("search-string-minium-length", () => {
+        it("adding the attribute should change the value of the search string minimum length", async () => {
+          const el = /** @type {MuchSelect} */ await fixture(
+            html`<much-select></much-select>`
+          );
+          expect(el.searchStringMinimumLength).to.equal(7);
+
+          el.setAttribute("search-string-minimum-length", "");
+          expect(el.searchStringMinimumLength).to.equal(7);
+
+          el.setAttribute("search-string-minimum-length", "5");
+          expect(el.searchStringMinimumLength).to.equal(7);
+        });
+      });
+    });
+});
+</script>
+</body>
+</html>

--- a/tests/Attributes/search-string-minimum-length.test.html
+++ b/tests/Attributes/search-string-minimum-length.test.html
@@ -16,18 +16,37 @@
 
   runTests(() => {
     describe("Attributes", () => {
-      describe("search-string-minium-length", () => {
-        it("adding the attribute should change the value of the search string minimum length", async () => {
+      describe("search-string-minimum-length", () => {
+        it("the default value should be 2", async () => {
           const el = /** @type {MuchSelect} */ await fixture(
             html`<much-select></much-select>`
           );
-          expect(el.searchStringMinimumLength).to.equal(7);
+          expect(el.searchStringMinimumLength).to.equal(2);
+        });
 
+        it("is empty the serach string minimum should be set to 0", async () => {
+          const el = /** @type {MuchSelect} */ await fixture(
+            html`<much-select></much-select>`
+          );
           el.setAttribute("search-string-minimum-length", "");
-          expect(el.searchStringMinimumLength).to.equal(7);
+          expect(el.searchStringMinimumLength).to.equal(0);
+        });
+
+        it("setting the attribute to a positive number should change the value", async () => {
+          const el = /** @type {MuchSelect} */ await fixture(
+            html`<much-select></much-select>`
+          );
 
           el.setAttribute("search-string-minimum-length", "5");
-          expect(el.searchStringMinimumLength).to.equal(7);
+          expect(el.searchStringMinimumLength).to.equal(5);
+        });
+
+        it("setting the attribute initially sets the minimum search string length", async () => {
+          const el = /** @type {MuchSelect} */ await fixture(
+            html`<much-select search-string-minimum-length="10"></much-select>`
+          );
+
+          expect(el.searchStringMinimumLength).to.equal(10);
         });
       });
     });

--- a/tests/IntegrationTests/DisplayingOptions.elm
+++ b/tests/IntegrationTests/DisplayingOptions.elm
@@ -28,6 +28,7 @@ flagsEmptyOptionsWithOrangeSelected =
     , disabled = False
     , allowCustomOptions = False
     , selectedItemStaysInPlace = True
+    , searchStringMinimumLength = 2
     }
 
 
@@ -99,6 +100,7 @@ flagsBookOptions =
     , disabled = False
     , allowCustomOptions = False
     , selectedItemStaysInPlace = True
+    , searchStringMinimumLength = 2
     }
 
 
@@ -115,6 +117,7 @@ flagsBookOptionsWithValue =
     , disabled = False
     , allowCustomOptions = False
     , selectedItemStaysInPlace = True
+    , searchStringMinimumLength = 2
     }
 
 
@@ -131,6 +134,7 @@ flagsBookOptionsWithSelected =
     , disabled = False
     , allowCustomOptions = False
     , selectedItemStaysInPlace = True
+    , searchStringMinimumLength = 2
     }
 
 


### PR DESCRIPTION
The `search-string-minimum-length` attribute is used to manage how many characters a user needs to type in the `#input-filter` before the options in the dropdown start being filtered.