### PR TITLE
116 bad search results just show everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,20 @@ The `selected-value` attribute is used to set the value of the `<much-select>`.
 
 The `show-dropdown-footer` attribute is used to show the footer in the dropdown of the `<much-select>`. The footer contains potentially useful information about how many options are really available but might not be visible because the results are being filter.
 
+#### Slots
+
+##### `no-options`
+
+If there are no options to display, show this message.
+
+##### `no-options`
+
+If there are no options to display, show this message.
+
+##### `no-filtered-options`
+
+If the user has typed in a search filter that just does not have any good matches show this message.
+
 #### Options
 
 ### Events

--- a/public/slots.html
+++ b/public/slots.html
@@ -259,6 +259,31 @@
     </much-select>
   </div>
 
+  <div>
+    <h3>No Options</h3>
+    <p>
+      You can over ride the message the user sees when there are no options.
+    </p>
+    <much-select>
+      <div slot="no-options">Oh bummmer, no options</div>
+    </much-select>
+  </div>
+
+  <div>
+    <h3>No Filtered Options</h3>
+    <p>
+      You can over ride the message the user sees when they have entered a search string that does not match any of the avalible options.
+    </p>
+    <much-select>
+      <div slot="no-filtered-options">Nope, you probably shouldn't drink that.</div>
+      <select slot="select-input">
+        <option>Black Tea</option>
+        <option>Green Tea</option>
+        <option>Red Tea</option>
+      </select>
+    </much-select>
+  </div>
+
 </div>
 
 <script src="./index.js" type="module"></script>

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -55,7 +55,7 @@ import Option
         )
 import OptionLabel exposing (OptionLabel(..), optionLabelToString)
 import OptionPresentor exposing (tokensToHtml)
-import OptionSearcher
+import OptionSearcher exposing (doesSearchStringFindNothing)
 import OptionSorting exposing (OptionSort(..), sortOptions, sortOptionsBySearchFilterTotalScore, stringToOptionSort)
 import Ports
     exposing
@@ -1160,6 +1160,9 @@ dropdown model =
         optionsHtml =
             if List.isEmpty model.optionsForTheDropdown then
                 [ div [ class "option disabled" ] [ node "slot" [ name "no-options" ] [ text "No available options" ] ] ]
+
+            else if doesSearchStringFindNothing model.searchString model.optionsForTheDropdown then
+                [ div [ class "option disabled" ] [ node "slot" [ name "no-filted-options" ] [ text "This filter returned no results." ] ] ]
 
             else
                 optionsToDropdownOptions

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1161,7 +1161,7 @@ dropdown model =
             if List.isEmpty model.optionsForTheDropdown then
                 [ div [ class "option disabled" ] [ node "slot" [ name "no-options" ] [ text "No available options" ] ] ]
 
-            else if doesSearchStringFindNothing model.searchString model.optionsForTheDropdown then
+            else if doesSearchStringFindNothing model.searchString model.searchStringMinimumLength model.optionsForTheDropdown then
                 [ div [ class "option disabled" ] [ node "slot" [ name "no-filted-options" ] [ text "This filter returned no results." ] ] ]
 
             else

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1162,7 +1162,7 @@ dropdown model =
                 [ div [ class "option disabled" ] [ node "slot" [ name "no-options" ] [ text "No available options" ] ] ]
 
             else if doesSearchStringFindNothing model.searchString model.searchStringMinimumLength model.optionsForTheDropdown then
-                [ div [ class "option disabled" ] [ node "slot" [ name "no-filted-options" ] [ text "This filter returned no results." ] ] ]
+                [ div [ class "option disabled" ] [ node "slot" [ name "no-filtered-options" ] [ text "This filter returned no results." ] ] ]
 
             else
                 optionsToDropdownOptions

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1158,6 +1158,7 @@ dropdown : Model -> Html Msg
 dropdown model =
     let
         optionsHtml =
+            -- TODO We should probably do something different if we are in a loading state
             if List.isEmpty model.optionsForTheDropdown then
                 [ div [ class "option disabled" ] [ node "slot" [ name "no-options" ] [ text "No available options" ] ] ]
 

--- a/src/OptionSearcher.elm
+++ b/src/OptionSearcher.elm
@@ -1,4 +1,4 @@
-module OptionSearcher exposing (simpleMatch, updateOptions)
+module OptionSearcher exposing (doesSearchStringFindNothing, simpleMatch, updateOptions)
 
 import Fuzzy exposing (Result, match)
 import Option exposing (Option)
@@ -99,3 +99,21 @@ updateOptionsWithSearchString searchString options =
                             )
                             option
                     )
+
+
+doesSearchStringFindNothing : String -> List Option -> Bool
+doesSearchStringFindNothing searchString options =
+    if String.length searchString <= 0 then
+        False
+
+    else
+        List.all
+            (\option ->
+                case Option.getMaybeOptionSearchFilter option of
+                    Just optionSearchFilter ->
+                        optionSearchFilter.totalScore > 1000
+
+                    Nothing ->
+                        False
+            )
+            options

--- a/src/OptionSearcher.elm
+++ b/src/OptionSearcher.elm
@@ -5,6 +5,7 @@ import Option exposing (Option)
 import OptionLabel exposing (optionLabelToSearchString, optionLabelToString)
 import OptionPresentor exposing (tokenize)
 import OptionSearchFilter exposing (OptionSearchResult)
+import PositiveInt exposing (PositiveInt)
 import SelectionMode exposing (CustomOptions(..), SelectionMode)
 
 
@@ -101,9 +102,9 @@ updateOptionsWithSearchString searchString options =
                     )
 
 
-doesSearchStringFindNothing : String -> List Option -> Bool
-doesSearchStringFindNothing searchString options =
-    if String.length searchString <= 0 then
+doesSearchStringFindNothing : String -> PositiveInt -> List Option -> Bool
+doesSearchStringFindNothing searchString searchStringMinimumLength options =
+    if String.length searchString <= PositiveInt.toInt searchStringMinimumLength then
         False
 
     else


### PR DESCRIPTION
If a user types in a search filter that's just totally bonkers (has no good matches) show a message saying there are no good search results.

The previous behavior was just to switch back to showing all the options.

![Screen Shot 2022-03-25 at 2 18 31 PM](https://user-images.githubusercontent.com/42679/160187312-f9341ff8-a784-4849-b223-46a0e1a037e8.png)
