### PR TITLE
Clicking the on the close dropdown button is not working

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -10,6 +10,7 @@
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
+            "elm-community/html-extra": "3.4.0",
             "elm-community/list-extra": "8.5.2",
             "elm-community/maybe-extra": "5.3.0",
             "elm-community/string-extra": "4.0.1",

--- a/public/example-partials/multi-select.html
+++ b/public/example-partials/multi-select.html
@@ -1,0 +1,14 @@
+<div id="simple-multi-select-example">
+  <h3>Multi Select</h3>
+  <p>Choose some colors, no need to just pick 1.</p>
+  <much-select multi-select="true">
+    <select slot="select-input">
+      <option>Red</option>
+      <option>Yellow</option>
+      <option>Orange</option>
+      <option>Green</option>
+      <option>Blue</option>
+      <option>Purple</option>
+    </select>
+  </much-select>
+</div>

--- a/public/index.html
+++ b/public/index.html
@@ -29,18 +29,8 @@
   </div>
 
   <div class="example">
-    <h3>Multi Select</h3>
-    <p>Choose some colors, no need to just pick 1.</p>
-    <much-select multi-select="true">
-      <select slot="select-input">
-        <option>Red</option>
-        <option>Yellow</option>
-        <option>Orange</option>
-        <option>Green</option>
-        <option>Blue</option>
-        <option>Purple</option>
-      </select>
-    </much-select>
+    <include src="example-partials/multi-select.html"></include>
+    <a href="multi-select-example.html">open example on its own page</a>
   </div>
 
   <div class="example">

--- a/public/multi-select-example.html
+++ b/public/multi-select-example.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<!--suppress HtmlFormInputWithoutLabel -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!--suppress HtmlUnknownTarget -->
+  <link rel="icon" href="./favicon.ico" type="image/x-icon" />
+  <title>Much Select</title>
+  <link href="demo-styles.css" rel="stylesheet">
+  <script src="./styles.js"></script>
+</head>
+
+<body>
+
+<include src="header.html">
+  {
+  "pageName": "Multi Select Example"
+  }
+</include>
+
+<include src="nav.html"></include>
+
+<div class="container">
+  <include src="example-partials/multi-select.html"></include>
+</div>
+
+<script src="./index.js" type="module"></script>
+</body>
+</html>

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -236,6 +236,7 @@ update msg model =
         InputFocus ->
             ( { model
                 | showDropdown = True
+                , focused = True
                 , rightSlot = updateRightSlotTransitioning False model.rightSlot
               }
             , Cmd.none

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -24,6 +24,7 @@ import Html.Attributes
         , type_
         , value
         )
+import Html.Attributes.Extra exposing (attributeIf)
 import Html.Events
     exposing
         ( onBlur
@@ -972,8 +973,8 @@ view model =
             div [ id "wrapper" ]
                 [ div
                     [ id "value-casing"
-                    , onMouseDown BringInputInFocus
-                    , onFocus BringInputInFocus
+                    , attributeIf (not model.focused) (onMouseDown BringInputInFocus)
+                    , attributeIf (not model.focused) (onFocus BringInputInFocus)
                     , tabIndexAttribute
                     , classList
                         [ ( "show-placeholder", showPlaceholder )
@@ -1077,7 +1078,7 @@ view model =
 
 
 singleSelectInputField : String -> Bool -> Bool -> String -> Bool -> Html Msg
-singleSelectInputField searchString isDisabled focused placeholder_ hasSelectedOptions =
+singleSelectInputField searchString isDisabled focused placeholder_ hasSelectedOption =
     let
         keyboardEvents =
             Keyboard.customPerKey Keyboard.Keydown
@@ -1136,7 +1137,7 @@ singleSelectInputField searchString isDisabled focused placeholder_ hasSelectedO
             onFocus InputFocus
 
         showPlaceholder =
-            not hasSelectedOptions && not focused
+            not hasSelectedOption && not focused
 
         placeholderAttribute =
             if showPlaceholder then
@@ -1153,7 +1154,7 @@ singleSelectInputField searchString isDisabled focused placeholder_ hasSelectedO
             ]
             []
 
-    else if hasSelectedOptions then
+    else if hasSelectedOption then
         input
             [ typeAttr
             , idAttr
@@ -1172,6 +1173,8 @@ singleSelectInputField searchString isDisabled focused placeholder_ hasSelectedO
             , idAttr
             , onBlurAttr
             , onFocusAttr
+            , onMouseDownStopPropagation NoOp
+            , onMouseUpStopPropagation NoOp
             , onInput SearchInputOnInput
             , value searchString
             , placeholderAttribute
@@ -1897,6 +1900,17 @@ onMouseDownStopPropagationAndPreventDefault message =
         )
 
 
+onMouseDownStopPropagation : msg -> Html.Attribute msg
+onMouseDownStopPropagation message =
+    Html.Events.custom "mousedown"
+        (Json.Decode.succeed
+            { message = message
+            , stopPropagation = True
+            , preventDefault = False
+            }
+        )
+
+
 onMouseUpStopPropagationAndPreventDefault : msg -> Html.Attribute msg
 onMouseUpStopPropagationAndPreventDefault message =
     Html.Events.custom "mouseup"
@@ -1904,5 +1918,16 @@ onMouseUpStopPropagationAndPreventDefault message =
             { message = message
             , stopPropagation = True
             , preventDefault = True
+            }
+        )
+
+
+onMouseUpStopPropagation : msg -> Html.Attribute msg
+onMouseUpStopPropagation message =
+    Html.Events.custom "mouseup"
+        (Json.Decode.succeed
+            { message = message
+            , stopPropagation = True
+            , preventDefault = False
             }
         )

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1032,6 +1032,8 @@ view model =
                         , onBlur InputBlur
                         , onFocus InputFocus
                         , onInput SearchInputOnInput
+                        , onMouseDownStopPropagation NoOp
+                        , onMouseUpStopPropagation NoOp
                         , value model.searchString
                         , placeholderAttribute
                         , id "input-filter"

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -325,7 +325,7 @@ class MuchSelect extends HTMLElement {
           });
         });
       },
-      10
+      5
     );
 
     this._callOptionChanged = makeDebounceLeadingFunc((optionsJson) => {


### PR DESCRIPTION
I managed to fix 2 related bugs in this PR. Both of them have to do with how events work.

1. The dropdown indicator (which should also act like a button) would not close the dropdown (unfocus).

2. Using the mouse to select text while filtering was not working. You could but you couldn't select, to delete or copy and paste.

A misc thing I did was break out another example so it could be opened on it's own.