### PR TITLE
Fix the example for selecting an option by changing the DOM.

### DIFF
--- a/public/example-partials/change-select-attribute-changes-selected-value-in-much-select.html
+++ b/public/example-partials/change-select-attribute-changes-selected-value-in-much-select.html
@@ -3,14 +3,16 @@
   <button id="select-moe">Select Moe with the selected attribute.</button>
   <much-select>
     <select slot="select-input">
-      <option>Larry</option>
+      <option id="larry">Larry</option>
       <option id="moe">Moe</option>
-      <option>Curly Joe</option>
+      <option id="joe">Curly Joe</option>
     </select>
   </much-select>
   <script>
     document.querySelector("#select-moe").addEventListener("click", () => {
+      document.querySelector("#larry").removeAttribute("selected");
       document.querySelector("#moe").setAttribute("selected", "");
+      document.querySelector("#joe").removeAttribute("selected");
     });
   </script>
 </div>

--- a/public/remote-api-example.html
+++ b/public/remote-api-example.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>$Title$</title>
+</head>
+<body>
+$END$
+</body>
+</html>

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -353,7 +353,7 @@ update msg model =
                     let
                         newOptionWithOldSelectedOption =
                             Option.replaceOptions
-                                (SelectionMode.getSelectedItemPlacementMode model.selectionMode)
+                                model.selectionMode
                                 model.options
                                 newOptions
                     in

--- a/src/Option.elm
+++ b/src/Option.elm
@@ -767,16 +767,43 @@ mergeTwoListsOfOptionsPreservingSelectedOptions selectedItemPlacementMode option
     setSelectedOptionInNewOptions superList newOptions
 
 
-replaceOptions : SelectedItemPlacementMode -> List Option -> List Option -> List Option
-replaceOptions selectedItemPlacementMode oldOptions newOptions =
+replaceOptions : SelectionMode -> List Option -> List Option -> List Option
+replaceOptions selectionMode oldOptions newOptions =
     let
         oldSelectedOptions =
             selectedOptions oldOptions
     in
-    mergeTwoListsOfOptionsPreservingSelectedOptions
-        selectedItemPlacementMode
-        oldSelectedOptions
-        newOptions
+    case selectionMode of
+        SingleSelect _ selectedItemPlacementMode ->
+            let
+                maybeSelectedOptionValue =
+                    selectedOptions (newOptions ++ oldOptions)
+                        |> List.head
+                        |> Maybe.map getOptionValue
+            in
+            case maybeSelectedOptionValue of
+                Just selectedOptionValue ->
+                    mergeTwoListsOfOptionsPreservingSelectedOptions
+                        selectedItemPlacementMode
+                        oldSelectedOptions
+                        newOptions
+                        |> selectSingleOptionInList selectedOptionValue
+                        |> List.filter
+                            (\option ->
+                                isOptionSelected option || List.member option newOptions
+                            )
+
+                Nothing ->
+                    mergeTwoListsOfOptionsPreservingSelectedOptions
+                        selectedItemPlacementMode
+                        oldSelectedOptions
+                        newOptions
+
+        MultiSelect _ _ ->
+            mergeTwoListsOfOptionsPreservingSelectedOptions
+                SelectedItemStaysInPlace
+                oldSelectedOptions
+                newOptions
 
 
 isOptionValueEqualToOptionLabel : Option -> Bool

--- a/tests/Option/ReplacingOptions.elm
+++ b/tests/Option/ReplacingOptions.elm
@@ -21,31 +21,80 @@ thirdEyeBlind =
 suite : Test
 suite =
     describe "Replacing options"
-        [ test "should not include options that were there before" <|
-            \_ ->
-                Expect.equalLists
-                    [ futureCop, theMidnight ]
-                    (Option.replaceOptions
-                        SelectionMode.SelectedItemStaysInPlace
-                        [ thirdEyeBlind, futureCop ]
+        [ describe "in multi select mode "
+            [ test "should not include options that were there before" <|
+                \_ ->
+                    Expect.equalLists
                         [ futureCop, theMidnight ]
-                    )
-        , test "should preserver selected options" <|
-            \_ ->
-                Expect.equalLists
-                    [ futureCop, Option.selectOption 0 theMidnight ]
-                    (Option.replaceOptions
-                        SelectionMode.SelectedItemStaysInPlace
-                        [ thirdEyeBlind, futureCop ]
+                        (Option.replaceOptions
+                            (SelectionMode.MultiSelect SelectionMode.NoCustomOptions SelectionMode.EnableSingleItemRemoval)
+                            [ thirdEyeBlind, futureCop ]
+                            [ futureCop, theMidnight ]
+                        )
+            , test "should preserver selected options" <|
+                \_ ->
+                    Expect.equalLists
                         [ futureCop, Option.selectOption 0 theMidnight ]
-                    )
-        , test "should preserver selected options even if the selected value is not in the new list of options" <|
-            \_ ->
-                Expect.equalLists
-                    (Option.replaceOptions
-                        SelectionMode.SelectedItemStaysInPlace
+                        (Option.replaceOptions
+                            (SelectionMode.MultiSelect SelectionMode.NoCustomOptions SelectionMode.EnableSingleItemRemoval)
+                            [ thirdEyeBlind, futureCop ]
+                            [ futureCop, Option.selectOption 0 theMidnight ]
+                        )
+            , test "should preserver selected options even if the selected value is not in the new list of options" <|
+                \_ ->
+                    Expect.equalLists
+                        (Option.replaceOptions
+                            (SelectionMode.MultiSelect SelectionMode.NoCustomOptions SelectionMode.EnableSingleItemRemoval)
+                            [ Option.selectOption 0 thirdEyeBlind, futureCop ]
+                            [ futureCop, theMidnight ]
+                        )
+                        [ futureCop, theMidnight, Option.selectOption 0 thirdEyeBlind ]
+            ]
+        , describe "in single select mode"
+            [ test "should preserver a single selected item in the new list of options" <|
+                \_ ->
+                    Expect.equalLists
+                        (Option.replaceOptions
+                            (SelectionMode.SingleSelect SelectionMode.NoCustomOptions SelectionMode.SelectedItemStaysInPlace)
+                            [ futureCop, theMidnight ]
+                            [ Option.selectOption 0 thirdEyeBlind, futureCop ]
+                        )
                         [ Option.selectOption 0 thirdEyeBlind, futureCop ]
-                        [ futureCop, theMidnight ]
-                    )
-                    [ futureCop, theMidnight, Option.selectOption 0 thirdEyeBlind ]
+            , test "should preserver a single selected item in the old list of options" <|
+                \_ ->
+                    Expect.equalLists
+                        (Option.replaceOptions
+                            (SelectionMode.SingleSelect SelectionMode.NoCustomOptions SelectionMode.SelectedItemStaysInPlace)
+                            [ Option.selectOption 0 thirdEyeBlind, theMidnight ]
+                            [ thirdEyeBlind, futureCop ]
+                        )
+                        [ Option.selectOption 0 thirdEyeBlind, futureCop ]
+            , test "should preserver a single selected item when the selected item is in both the old and new list" <|
+                \_ ->
+                    Expect.equalLists
+                        (Option.replaceOptions
+                            (SelectionMode.SingleSelect SelectionMode.NoCustomOptions SelectionMode.SelectedItemStaysInPlace)
+                            [ Option.selectOption 0 thirdEyeBlind, theMidnight ]
+                            [ Option.selectOption 0 thirdEyeBlind, futureCop ]
+                        )
+                        [ Option.selectOption 0 thirdEyeBlind, futureCop ]
+            , test "should preserver a single selected item when the selected item is NOT in the new list" <|
+                \_ ->
+                    Expect.equalLists
+                        (Option.replaceOptions
+                            (SelectionMode.SingleSelect SelectionMode.NoCustomOptions SelectionMode.SelectedItemStaysInPlace)
+                            [ Option.selectOption 0 thirdEyeBlind, theMidnight ]
+                            [ futureCop ]
+                        )
+                        [ futureCop, Option.selectOption 0 thirdEyeBlind ]
+            , test "should preserver a single selected item when different items are selected in the old and new list, favoring the new selected option" <|
+                \_ ->
+                    Expect.equalLists
+                        (Option.replaceOptions
+                            (SelectionMode.SingleSelect SelectionMode.NoCustomOptions SelectionMode.SelectedItemStaysInPlace)
+                            [ Option.selectOption 0 thirdEyeBlind, theMidnight ]
+                            [ Option.selectOption 0 futureCop ]
+                        )
+                        [ Option.selectOption 0 futureCop ]
+            ]
         ]


### PR DESCRIPTION
Ensure that only 1 option is selected in single select mode when replacing options.

Updating the example too, to remove any selected attributes from options
that are not Moe.