### PR TITLE
Fixing a bug that was causing a glitch in the view.

### DIFF
--- a/src/much-select.js
+++ b/src/much-select.js
@@ -822,6 +822,13 @@ class MuchSelect extends HTMLElement {
           // We do no need to update the options if we are updating the placeholder.
           return;
         }
+        if (
+          mutation.type === "attributes" &&
+          mutation.attributeName === "loading"
+        ) {
+          // We do no need to update the options if we are updating the loading attribute.
+          return;
+        }
         this._callUpdateOptionsFromDom();
       });
     });


### PR DESCRIPTION
We do not need to updates the options in the DOM when the loading
attribute is changed.