### PR TITLE
185 elm demo filtered options for datalist

### DIFF
--- a/public/output-style-datalist-single-select.html
+++ b/public/output-style-datalist-single-select.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<!--suppress HtmlFormInputWithoutLabel -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!--suppress HtmlUnknownTarget -->
+  <link rel="icon" href="./favicon.ico" type="image/x-icon" />
+  <title>Much Select - Datalist Single Select</title>
+  <link href="demo-styles.css" rel="stylesheet">
+  <script src="./styles.js"></script>
+</head>
+
+<body>
+
+<include src="header.html">
+  {
+  "pageName": "Datalist Single Select"
+  }
+</include>
+
+<include src="nav.html"></include>
+
+<div class="container">
+  <div class="example">
+    <include src="example-partials/output-style-datalist.html"></include>
+  </div>
+</div>
+
+<script src="./index.js" type="module"></script>
+</body>
+</html>

--- a/public/output-style-datalist.html
+++ b/public/output-style-datalist.html
@@ -23,6 +23,7 @@
 <div class="container">
   <div class="example">
     <include src="example-partials/output-style-datalist.html"></include>
+    <a href="output-style-datalist-single-select.html">open example on it's own page</a>
   </div>
 
   <div class="example">

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -196,7 +196,7 @@ type Effect
     | BlurInput
     | InputHasBeenFocused
     | InputHasBeenBlurred
-    | InputHasBeenKeyUp String
+    | InputHasBeenKeyUp String TransformAndValidate.ValidationStatus
     | SearchStringTouched Float
     | UpdateOptionsInWebWorker
     | SearchOptionsWithWebWorker Json.Decode.Value
@@ -453,7 +453,7 @@ update msg model =
                 , searchStringBounce = Bounce.push model.searchStringBounce
               }
             , batch
-                [ InputHasBeenKeyUp searchString
+                [ InputHasBeenKeyUp searchString TransformAndValidate.InputValidationIsNotHappening
                 , SearchStringTouched model.searchStringDebounceLength
                 ]
             )
@@ -488,7 +488,7 @@ update msg model =
                         [ makeEffectsWhenValuesChanges
                             (updatedOptions |> selectedOptions |> OptionsUtilities.cleanupEmptySelectedOptions)
                             maybeSelectedOptionValue
-                        , InputHasBeenKeyUp valueString
+                        , InputHasBeenKeyUp valueString TransformAndValidate.InputHasBeenValidated
                         ]
                     )
 
@@ -517,7 +517,7 @@ update msg model =
                         [ makeEffectsWhenValuesChanges
                             (updatedOptions |> selectedOptions |> OptionsUtilities.cleanupEmptySelectedOptions)
                             maybeSelectedOptionValue
-                        , InputHasBeenKeyUp valueString
+                        , InputHasBeenKeyUp valueString TransformAndValidate.InputHasFailedValidation
                         ]
                     )
 
@@ -545,7 +545,7 @@ update msg model =
                         [ makeEffectsWhenValuesChanges
                             (updatedOptions |> selectedOptions |> OptionsUtilities.cleanupEmptySelectedOptions)
                             maybeSelectedOptionValue
-                        , InputHasBeenKeyUp valueString
+                        , InputHasBeenKeyUp valueString TransformAndValidate.InputHasValidationPending
                         ]
                     )
 
@@ -563,7 +563,7 @@ update msg model =
                 | searchString = SearchString.new inputString
                 , options = updateOrAddCustomOption (SearchString.new inputString) model.selectionConfig model.options
               }
-            , InputHasBeenKeyUp inputString
+            , InputHasBeenKeyUp inputString TransformAndValidate.InputValidationIsNotHappening
             )
 
         ValueChanged valuesJson ->
@@ -1193,7 +1193,7 @@ perform effect =
         InputHasBeenFocused ->
             inputFocused ()
 
-        InputHasBeenKeyUp string ->
+        InputHasBeenKeyUp string _ ->
             inputKeyUp string
 
         UpdateOptionsInWebWorker ->

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -484,9 +484,12 @@ update msg model =
                         | options = updatedOptions
                         , rightSlot = updateRightSlot model.rightSlot model.selectionConfig True (updatedOptions |> selectedOptions)
                       }
-                    , makeEffectsWhenValuesChanges
-                        (updatedOptions |> selectedOptions |> OptionsUtilities.cleanupEmptySelectedOptions)
-                        maybeSelectedOptionValue
+                    , batch
+                        [ makeEffectsWhenValuesChanges
+                            (updatedOptions |> selectedOptions |> OptionsUtilities.cleanupEmptySelectedOptions)
+                            maybeSelectedOptionValue
+                        , InputHasBeenKeyUp valueString
+                        ]
                     )
 
                 TransformAndValidate.ValidationFailed _ _ validationErrorMessages ->
@@ -510,9 +513,12 @@ update msg model =
                                 True
                                 (updatedOptions |> selectedOptions)
                       }
-                    , makeEffectsWhenValuesChanges
-                        (updatedOptions |> selectedOptions |> OptionsUtilities.cleanupEmptySelectedOptions)
-                        maybeSelectedOptionValue
+                    , batch
+                        [ makeEffectsWhenValuesChanges
+                            (updatedOptions |> selectedOptions |> OptionsUtilities.cleanupEmptySelectedOptions)
+                            maybeSelectedOptionValue
+                        , InputHasBeenKeyUp valueString
+                        ]
                     )
 
                 TransformAndValidate.ValidationPending _ _ ->
@@ -535,9 +541,12 @@ update msg model =
                                 True
                                 (updatedOptions |> selectedOptions)
                       }
-                    , makeEffectsWhenValuesChanges
-                        (updatedOptions |> selectedOptions |> OptionsUtilities.cleanupEmptySelectedOptions)
-                        maybeSelectedOptionValue
+                    , batch
+                        [ makeEffectsWhenValuesChanges
+                            (updatedOptions |> selectedOptions |> OptionsUtilities.cleanupEmptySelectedOptions)
+                            maybeSelectedOptionValue
+                        , InputHasBeenKeyUp valueString
+                        ]
                     )
 
         UpdateOptionsWithSearchString ->
@@ -2033,6 +2042,7 @@ singleSelectDatasetInputField maybeOption selectionMode hasSelectedOption =
         input
             [ typeAttr
             , idAttr
+            , ariaLabel
             , partAttr
             , onBlurAttr
             , onFocusAttr

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1886,6 +1886,9 @@ multiSelectDatasetInputField maybeOption selectionConfig rightSlot index =
         idAttr =
             id ("input-value-" ++ String.fromInt index)
 
+        ariaLabel =
+            Html.Attributes.attribute "aria-label" "much-select-value"
+
         errorIdAttr =
             id ("error-input-value-" ++ String.fromInt index)
 
@@ -1921,6 +1924,7 @@ multiSelectDatasetInputField maybeOption selectionConfig rightSlot index =
                 input
                     [ disabled True
                     , idAttr
+                    , ariaLabel
                     , Html.Attributes.attribute "part" "input-value"
                     , placeholderAttribute
                     , classList classes
@@ -1931,6 +1935,7 @@ multiSelectDatasetInputField maybeOption selectionConfig rightSlot index =
                 input
                     [ typeAttr
                     , idAttr
+                    , ariaLabel
                     , Html.Attributes.attribute "part" "input-value"
                     , classList classes
                     , onInput (UpdateOptionValueValue index)
@@ -1981,6 +1986,9 @@ singleSelectDatasetInputField maybeOption selectionMode hasSelectedOption =
         idAttr =
             id "input-value"
 
+        ariaLabel =
+            Html.Attributes.attribute "aria-label" "much-select-value"
+
         partAttr =
             Html.Attributes.attribute "part" "input-value"
 
@@ -2015,6 +2023,7 @@ singleSelectDatasetInputField maybeOption selectionMode hasSelectedOption =
         input
             [ disabled True
             , idAttr
+            , ariaLabel
             , partAttr
             , placeholderAttribute
             ]

--- a/src/TransformAndValidate.elm
+++ b/src/TransformAndValidate.elm
@@ -39,6 +39,13 @@ type ValidationResult
     | ValidationPending String Int
 
 
+type ValidationStatus
+    = InputHasBeenValidated
+    | InputHasValidationPending
+    | InputHasFailedValidation
+    | InputValidationIsNotHappening
+
+
 getSelectedIndexFromValidationResult : ValidationResult -> Int
 getSelectedIndexFromValidationResult validationResult =
     case validationResult of

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -598,16 +598,7 @@ class MuchSelect extends HTMLElement {
 
     // noinspection JSUnresolvedVariable
     this.appPromise.then((app) =>
-      app.ports.inputKeyUp.subscribe((searchString) => {
-        this.dispatchEvent(
-          new CustomEvent("inputKeyUp", {
-            bubbles: true,
-            detail: { searchString },
-          })
-        );
-
-        this._inputKeypressDebounceHandler(searchString);
-      })
+      app.ports.inputKeyUp.subscribe(this._handleInputKeyUp.bind(this))
     );
 
     // noinspection JSUnresolvedVariable
@@ -1304,6 +1295,17 @@ class MuchSelect extends HTMLElement {
         `In single select mode we are expecting a single custom option, instead we got ${values.length}`
       );
     }
+  }
+
+  _handleInputKeyUp(searchString) {
+    this.dispatchEvent(
+      new CustomEvent("inputKeyUp", {
+        bubbles: true,
+        detail: { searchString },
+      })
+    );
+
+    this._inputKeypressDebounceHandler(searchString);
   }
 
   get appPromise() {

--- a/tests/Events/Kepress.elm
+++ b/tests/Events/Kepress.elm
@@ -43,7 +43,7 @@ flagsDatalistSingle =
 simulateEffects : Main.Effect -> ProgramTest.SimulatedEffect Main.Msg
 simulateEffects effect =
     case effect of
-        Main.InputHasBeenKeyUp string ->
+        Main.InputHasBeenKeyUp string _ ->
             SimulatedEffect.Ports.send "inputKeyUp" (Json.Encode.string string)
 
         Main.Batch effects ->

--- a/tests/Events/Kepress.elm
+++ b/tests/Events/Kepress.elm
@@ -1,0 +1,82 @@
+module Events.Kepress exposing (suite)
+
+import Expect
+import Json.Decode
+import Json.Encode
+import Main exposing (Flags)
+import ProgramTest exposing (ensureViewHas, expectOutgoingPortValues, fillIn, start)
+import SimulatedEffect.Cmd
+import SimulatedEffect.Ports
+import Test exposing (Test, describe, test)
+import Test.Html.Selector exposing (all, classes, id)
+
+
+element =
+    ProgramTest.createElement
+        { init = Main.init
+        , update = Main.update
+        , view = Main.view
+        }
+
+
+flagsDatalistSingle : Flags
+flagsDatalistSingle =
+    { value = Json.Encode.object []
+    , placeholder = ( True, "" )
+    , customOptionHint = Nothing
+    , allowMultiSelect = False
+    , outputStyle = "datalist"
+    , enableMultiSelectSingleItemRemoval = False
+    , optionsJson = ""
+    , optionSort = ""
+    , loading = False
+    , maxDropdownItems = 2
+    , disabled = False
+    , allowCustomOptions = False
+    , selectedItemStaysInPlace = True
+    , searchStringMinimumLength = 2
+    , showDropdownFooter = False
+    , transformationAndValidationJson = ""
+    }
+
+
+simulateEffects : Main.Effect -> ProgramTest.SimulatedEffect Main.Msg
+simulateEffects effect =
+    case effect of
+        Main.InputHasBeenKeyUp string ->
+            SimulatedEffect.Ports.send "inputKeyUp" (Json.Encode.string string)
+
+        Main.Batch effects ->
+            effects
+                |> List.map simulateEffects
+                |> SimulatedEffect.Cmd.batch
+
+        _ ->
+            SimulatedEffect.Cmd.none
+
+
+suite : Test
+suite =
+    describe "There should be an outgoing input key up port triggered"
+        [ test "when in datalist output mode" <|
+            \() ->
+                element
+                    |> ProgramTest.withSimulatedEffects simulateEffects
+                    |> start flagsDatalistSingle
+                    |> ensureViewHas
+                        [ all
+                            [ id "value-casing"
+                            , classes
+                                [ "no-option-selected"
+                                , "single"
+                                , "output-style-datalist"
+                                , "not-focused"
+                                ]
+                            ]
+                        ]
+                    |> fillIn "input-value" "much-select-value" "hello"
+                    |> expectOutgoingPortValues
+                        "inputKeyUp"
+                        Json.Decode.string
+                        (Expect.equal [ "hello" ])
+        ]

--- a/tests/Option/SelectedOptionOrdering.elm
+++ b/tests/Option/SelectedOptionOrdering.elm
@@ -7,8 +7,7 @@ import ProgramTest exposing (ProgramTest)
 import SimulatedEffect.Cmd
 import SimulatedEffect.Ports
 import Test exposing (Test, describe, test)
-import Test.Html.Query exposing (find)
-import Test.Html.Selector exposing (all, class, classes, containing, exactClassName, id, text)
+import Test.Html.Selector exposing (all, classes, containing, id, text)
 
 
 booksJsonWithIndexesAndWithSelected =
@@ -81,7 +80,7 @@ simulatedEffects effect =
         Main.InputHasBeenBlurred ->
             SimulatedEffect.Ports.send "inputBlurred" (Json.Encode.object [])
 
-        Main.InputHasBeenKeyUp string ->
+        Main.InputHasBeenKeyUp string _ ->
             SimulatedEffect.Ports.send "inputKeyUp" (Json.Encode.string string)
 
         Main.SearchStringTouched _ ->


### PR DESCRIPTION
Fixing a bug that causes `<much-select>` with `output-style="datalist"` to not emit events for key presses.

Adding a standalone example for Datalist Single Select