### PR TITLE
When focusing with a click, don't actually focus until mouse up.

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -27,6 +27,7 @@ import Html.Events
         , onMouseDown
         , onMouseEnter
         , onMouseLeave
+        , onMouseUp
         )
 import Html.Lazy
 import Json.Decode
@@ -1554,7 +1555,10 @@ singleSelectViewCustomHtml selectionConfig options searchString rightSlot =
     div
         [ id "value-casing"
         , valueCasingPartsAttribute selectionConfig hasErrors hasPendingValidation
-        , attributeIf (not (isFocused selectionConfig)) (onMouseDown BringInputInFocus)
+
+        -- TODO On mouse down do something to provide a bit of feedback
+        , attributeIf (not (isFocused selectionConfig)) (onMouseDown NoOp)
+        , attributeIf (not (isFocused selectionConfig)) (onMouseUp BringInputInFocus)
         , attributeIf (not (isFocused selectionConfig)) (onFocus BringInputInFocus)
         , tabIndexAttribute (isDisabled selectionConfig)
         , classList
@@ -1637,7 +1641,10 @@ multiSelectViewCustomHtml selectionConfig options searchString rightSlot =
     div
         [ id "value-casing"
         , valueCasingPartsAttribute selectionConfig hasErrors hasPendingValidation
-        , onMouseDown BringInputInFocus
+
+        -- TODO On mouse down do something to provide a bit of feedback
+        , onMouseDown NoOp
+        , onMouseUp BringInputInFocus
         , onFocus BringInputInFocus
         , Keyboard.on Keyboard.Keydown
             [ ( Delete, DeleteKeydownForMultiSelect )


### PR DESCRIPTION
This is a follow up to https://github.com/DripEmail/much-select-elm/pull/195

After poking around a bit I realized if I clicked on the very bottom of the `<much-select>` I'd end up selecting the first item in the drop down (this in with the Drip styles).

So this is yet another case where we don't want to actually do "the thing" until mouse up.