### PR TITLE
Options being updated when there was no need

### DIFF
--- a/dist/much-select-debug.js
+++ b/dist/much-select-debug.js
@@ -683,28 +683,14 @@ class MuchSelect extends HTMLElement {
   startMuchSelectObserver() {
     // Options for the observer (which mutations to observe)
     const muchSelectMutationObserverConfig = {
-      attributes: true,
+      attributes: false,
       childList: true,
       subtree: false,
       characterData: false,
     };
 
     this._muchSelectObserver = new MutationObserver((mutationsList) => {
-      mutationsList.forEach((mutation) => {
-        if (
-          mutation.type === "attributes" &&
-          mutation.attributeName === "placeholder"
-        ) {
-          // We do no need to update the options if we are updating the placeholder.
-          return;
-        }
-        if (
-          mutation.type === "attributes" &&
-          mutation.attributeName === "loading"
-        ) {
-          // We do no need to update the options if we are updating the loading attribute.
-          return;
-        }
+      mutationsList.forEach(() => {
         this._callUpdateOptionsFromDom();
       });
     });

--- a/dist/much-select-elm-debug.js
+++ b/dist/much-select-elm-debug.js
@@ -14977,7 +14977,8 @@ var $author$project$OptionSearcher$encodeSearchParams = F4(
 				]));
 	});
 var $author$project$OptionsUtilities$filterOptionsToShowInDropdownByOptionDisplay = function (selectionConfig) {
-	if (selectionConfig.$ === 'SingleSelectConfig') {
+	var _v0 = $author$project$SelectionMode$getSelectionMode(selectionConfig);
+	if (_v0.$ === 'SingleSelect') {
 		return $elm$core$List$filter(
 			function (option) {
 				var _v1 = $author$project$Option$getOptionDisplay(option);
@@ -15508,7 +15509,7 @@ var $author$project$OptionsUtilities$moveHighlightedOptionDown = F3(
 			var option = maybeLowerSibling.a;
 			return A2($author$project$OptionsUtilities$highlightOptionInList, option, allOptions);
 		} else {
-			var _v1 = $elm$core$List$head(visibleOptions);
+			var _v1 = A3($author$project$OptionsUtilities$findClosestHighlightableOptionGoingDown, selectionConfig, 0, visibleOptions);
 			if (_v1.$ === 'Just') {
 				var firstOption = _v1.a;
 				return A2($author$project$OptionsUtilities$highlightOptionInList, firstOption, allOptions);
@@ -17036,14 +17037,15 @@ var $author$project$MuchSelect$update = F2(
 							$author$project$MuchSelect$ReportErrorMessage('Unable to select option'));
 					}
 				} else {
+					var visibleOptions = A2($author$project$MuchSelect$figureOutWhichOptionsToShowInTheDropdown, model.selectionConfig, model.options);
+					var moveHighlightedOptionDownIfThereAreOptions = F2(
+						function (selectionConfig, options) {
+							return ($elm$core$List$length(visibleOptions) > 1) ? A2($author$project$OptionsUtilities$moveHighlightedOptionDown, selectionConfig, options) : $elm$core$Basics$identity;
+						});
 					var updatedOptions = A2(
 						$author$project$OptionsUtilities$selectOptionInListByOptionValue,
 						optionValue,
-						A3(
-							$author$project$OptionsUtilities$moveHighlightedOptionDown,
-							model.selectionConfig,
-							model.options,
-							A2($author$project$MuchSelect$figureOutWhichOptionsToShowInTheDropdown, model.selectionConfig, model.options)));
+						A3(moveHighlightedOptionDownIfThereAreOptions, model.selectionConfig, model.options, visibleOptions));
 					var maybeNewlySelectedOption = A2($author$project$OptionsUtilities$findOptionByOptionValue, optionValue, updatedOptions);
 					if (maybeNewlySelectedOption.$ === 'Just') {
 						var newlySelectedOption = maybeNewlySelectedOption.a;
@@ -18624,13 +18626,6 @@ var $author$project$MuchSelect$onClickPreventDefaultAndStopPropagation = functio
 		$elm$json$Json$Decode$succeed(
 			{message: message, preventDefault: true, stopPropagation: true}));
 };
-var $author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault = function (message) {
-	return A2(
-		$elm$html$Html$Events$custom,
-		'mousedown',
-		$elm$json$Json$Decode$succeed(
-			{message: message, preventDefault: true, stopPropagation: true}));
-};
 var $elm$html$Html$Events$onMouseEnter = function (msg) {
 	return A2(
 		$elm$html$Html$Events$on,
@@ -18642,13 +18637,6 @@ var $elm$html$Html$Events$onMouseLeave = function (msg) {
 		$elm$html$Html$Events$on,
 		'mouseleave',
 		$elm$json$Json$Decode$succeed(msg));
-};
-var $author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault = function (message) {
-	return A2(
-		$elm$html$Html$Events$custom,
-		'mouseup',
-		$elm$json$Json$Decode$succeed(
-			{message: message, preventDefault: true, stopPropagation: true}));
 };
 var $author$project$Option$optionDescriptionToBool = function (optionDescription) {
 	if (optionDescription.$ === 'OptionDescription') {
@@ -18764,10 +18752,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.mouseOutMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault(
+										$author$project$MuchSelect$mousedownPreventDefault(
 										eventHandlers.mouseDownMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault(
+										$author$project$MuchSelect$mousedownPreventDefault(
 										eventHandlers.mouseUpMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
 										$author$project$MuchSelect$onClickPreventDefault(eventHandlers.noOpMsgConstructor),
@@ -18823,7 +18811,8 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 						case 'OptionSelectedAndInvalid':
 							return $elm$html$Html$text('');
 						case 'OptionSelectedHighlighted':
-							if (selectionConfig.$ === 'SingleSelectConfig') {
+							var _v2 = $author$project$SelectionMode$getSelectionMode(selectionConfig);
+							if (_v2.$ === 'SingleSelect') {
 								return A2(
 									$elm$html$Html$div,
 									_List_fromArray(
@@ -18862,10 +18851,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.mouseOutMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault(
+										$author$project$MuchSelect$mousedownPreventDefault(
 										eventHandlers.mouseDownMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault(
+										$author$project$MuchSelect$mousedownPreventDefault(
 										eventHandlers.mouseUpMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
 										A2($elm$html$Html$Attributes$attribute, 'part', 'dropdown-option highlighted'),
@@ -18898,10 +18887,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.mouseOutMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault(
+										$author$project$MuchSelect$mousedownPreventDefault(
 										eventHandlers.mouseDownMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault(
+										$author$project$MuchSelect$mousedownPreventDefault(
 										eventHandlers.mouseUpMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
 										$author$project$MuchSelect$onClickPreventDefaultAndStopPropagation(eventHandlers.noOpMsgConstructor),
@@ -19890,6 +19879,20 @@ var $author$project$MuchSelect$defaultLoadingIndicator = A2(
 		]),
 	_List_Nil);
 var $author$project$MuchSelect$BringInputOutOfFocus = {$: 'BringInputOutOfFocus'};
+var $author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault = function (message) {
+	return A2(
+		$elm$html$Html$Events$custom,
+		'mousedown',
+		$elm$json$Json$Decode$succeed(
+			{message: message, preventDefault: true, stopPropagation: true}));
+};
+var $author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault = function (message) {
+	return A2(
+		$elm$html$Html$Events$custom,
+		'mouseup',
+		$elm$json$Json$Decode$succeed(
+			{message: message, preventDefault: true, stopPropagation: true}));
+};
 var $author$project$MuchSelect$dropdownIndicator = F2(
 	function (interactionState, transitioning) {
 		if (interactionState.$ === 'Disabled') {

--- a/dist/much-select-elm-debug.js
+++ b/dist/much-select-elm-debug.js
@@ -17036,7 +17036,14 @@ var $author$project$MuchSelect$update = F2(
 							$author$project$MuchSelect$ReportErrorMessage('Unable to select option'));
 					}
 				} else {
-					var updatedOptions = A2($author$project$OptionsUtilities$selectOptionInListByOptionValue, optionValue, model.options);
+					var updatedOptions = A2(
+						$author$project$OptionsUtilities$selectOptionInListByOptionValue,
+						optionValue,
+						A3(
+							$author$project$OptionsUtilities$moveHighlightedOptionDown,
+							model.selectionConfig,
+							model.options,
+							A2($author$project$MuchSelect$figureOutWhichOptionsToShowInTheDropdown, model.selectionConfig, model.options)));
 					var maybeNewlySelectedOption = A2($author$project$OptionsUtilities$findOptionByOptionValue, optionValue, updatedOptions);
 					if (maybeNewlySelectedOption.$ === 'Just') {
 						var newlySelectedOption = maybeNewlySelectedOption.a;
@@ -18610,6 +18617,20 @@ var $author$project$MuchSelect$onClickPreventDefault = function (message) {
 		$elm$json$Json$Decode$succeed(
 			{message: message, preventDefault: true, stopPropagation: false}));
 };
+var $author$project$MuchSelect$onClickPreventDefaultAndStopPropagation = function (message) {
+	return A2(
+		$elm$html$Html$Events$custom,
+		'click',
+		$elm$json$Json$Decode$succeed(
+			{message: message, preventDefault: true, stopPropagation: true}));
+};
+var $author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault = function (message) {
+	return A2(
+		$elm$html$Html$Events$custom,
+		'mousedown',
+		$elm$json$Json$Decode$succeed(
+			{message: message, preventDefault: true, stopPropagation: true}));
+};
 var $elm$html$Html$Events$onMouseEnter = function (msg) {
 	return A2(
 		$elm$html$Html$Events$on,
@@ -18621,6 +18642,13 @@ var $elm$html$Html$Events$onMouseLeave = function (msg) {
 		$elm$html$Html$Events$on,
 		'mouseleave',
 		$elm$json$Json$Decode$succeed(msg));
+};
+var $author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault = function (message) {
+	return A2(
+		$elm$html$Html$Events$custom,
+		'mouseup',
+		$elm$json$Json$Decode$succeed(
+			{message: message, preventDefault: true, stopPropagation: true}));
 };
 var $author$project$Option$optionDescriptionToBool = function (optionDescription) {
 	if (optionDescription.$ === 'OptionDescription') {
@@ -18736,10 +18764,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.mouseOutMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault(
 										eventHandlers.mouseDownMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mouseupPreventDefault(
+										$author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault(
 										eventHandlers.mouseUpMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
 										$author$project$MuchSelect$onClickPreventDefault(eventHandlers.noOpMsgConstructor),
@@ -18834,10 +18862,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.mouseOutMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault(
 										eventHandlers.mouseDownMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mouseupPreventDefault(
+										$author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault(
 										eventHandlers.mouseUpMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
 										A2($elm$html$Html$Attributes$attribute, 'part', 'dropdown-option highlighted'),
@@ -18870,13 +18898,13 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.mouseOutMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault(
 										eventHandlers.mouseDownMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mouseupPreventDefault(
+										$author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault(
 										eventHandlers.mouseUpMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$onClickPreventDefault(eventHandlers.noOpMsgConstructor),
+										$author$project$MuchSelect$onClickPreventDefaultAndStopPropagation(eventHandlers.noOpMsgConstructor),
 										A2($elm$html$Html$Attributes$attribute, 'part', 'dropdown-option active'),
 										$elm$html$Html$Attributes$class('option'),
 										$elm$html$Html$Attributes$class('active'),
@@ -19862,20 +19890,6 @@ var $author$project$MuchSelect$defaultLoadingIndicator = A2(
 		]),
 	_List_Nil);
 var $author$project$MuchSelect$BringInputOutOfFocus = {$: 'BringInputOutOfFocus'};
-var $author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault = function (message) {
-	return A2(
-		$elm$html$Html$Events$custom,
-		'mousedown',
-		$elm$json$Json$Decode$succeed(
-			{message: message, preventDefault: true, stopPropagation: true}));
-};
-var $author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault = function (message) {
-	return A2(
-		$elm$html$Html$Events$custom,
-		'mouseup',
-		$elm$json$Json$Decode$succeed(
-			{message: message, preventDefault: true, stopPropagation: true}));
-};
 var $author$project$MuchSelect$dropdownIndicator = F2(
 	function (interactionState, transitioning) {
 		if (interactionState.$ === 'Disabled') {
@@ -19930,13 +19944,6 @@ var $author$project$MuchSelect$dropdownIndicator = F2(
 					]));
 		}
 	});
-var $author$project$MuchSelect$onClickPreventDefaultAndStopPropagation = function (message) {
-	return A2(
-		$elm$html$Html$Events$custom,
-		'click',
-		$elm$json$Json$Decode$succeed(
-			{message: message, preventDefault: true, stopPropagation: true}));
-};
 var $author$project$MuchSelect$defaultRemoveButton = A2(
 	$elm$html$Html$button,
 	_List_Nil,

--- a/dist/much-select-elm-debug.js
+++ b/dist/much-select-elm-debug.js
@@ -18598,14 +18598,14 @@ var $elm$html$Html$Events$custom = F2(
 			event,
 			$elm$virtual_dom$VirtualDom$Custom(decoder));
 	});
-var $author$project$MuchSelect$mousedownPreventDefault = function (message) {
+var $author$project$MuchSelect$mouseDownPreventDefault = function (message) {
 	return A2(
 		$elm$html$Html$Events$custom,
 		'mousedown',
 		$elm$json$Json$Decode$succeed(
 			{message: message, preventDefault: true, stopPropagation: false}));
 };
-var $author$project$MuchSelect$mouseupPreventDefault = function (message) {
+var $author$project$MuchSelect$mouseUpPreventDefault = function (message) {
 	return A2(
 		$elm$html$Html$Events$custom,
 		'mouseup',
@@ -18752,10 +18752,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.mouseOutMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$mouseDownPreventDefault(
 										eventHandlers.mouseDownMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$mouseUpPreventDefault(
 										eventHandlers.mouseUpMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
 										$author$project$MuchSelect$onClickPreventDefault(eventHandlers.noOpMsgConstructor),
@@ -18780,10 +18780,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 											$elm$html$Html$Events$onMouseLeave(
 											eventHandlers.mouseOutMsgConstructor(
 												$author$project$Option$getOptionValue(option))),
-											$author$project$MuchSelect$mousedownPreventDefault(
+											$author$project$MuchSelect$mouseDownPreventDefault(
 											eventHandlers.mouseDownMsgConstructor(
 												$author$project$Option$getOptionValue(option))),
-											$author$project$MuchSelect$mouseupPreventDefault(
+											$author$project$MuchSelect$mouseUpPreventDefault(
 											eventHandlers.mouseUpMsgConstructor(
 												$author$project$Option$getOptionValue(option))),
 											A2($elm$html$Html$Attributes$attribute, 'part', 'dropdown-option selected'),
@@ -18823,10 +18823,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 											$elm$html$Html$Events$onMouseLeave(
 											eventHandlers.mouseOutMsgConstructor(
 												$author$project$Option$getOptionValue(option))),
-											$author$project$MuchSelect$mousedownPreventDefault(
+											$author$project$MuchSelect$mouseDownPreventDefault(
 											eventHandlers.mouseDownMsgConstructor(
 												$author$project$Option$getOptionValue(option))),
-											$author$project$MuchSelect$mouseupPreventDefault(
+											$author$project$MuchSelect$mouseUpPreventDefault(
 											eventHandlers.mouseUpMsgConstructor(
 												$author$project$Option$getOptionValue(option))),
 											A2($elm$html$Html$Attributes$attribute, 'part', 'dropdown-option selected highlighted'),
@@ -18851,10 +18851,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.mouseOutMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$mouseDownPreventDefault(
 										eventHandlers.mouseDownMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$mouseUpPreventDefault(
 										eventHandlers.mouseUpMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
 										A2($elm$html$Html$Attributes$attribute, 'part', 'dropdown-option highlighted'),
@@ -18887,10 +18887,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.mouseOutMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$mouseDownPreventDefault(
 										eventHandlers.mouseDownMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$mouseUpPreventDefault(
 										eventHandlers.mouseUpMsgConstructor(
 											$author$project$Option$getOptionValue(option))),
 										$author$project$MuchSelect$onClickPreventDefaultAndStopPropagation(eventHandlers.noOpMsgConstructor),
@@ -19651,7 +19651,7 @@ var $author$project$MuchSelect$valueLabelHtml = F2(
 			_List_fromArray(
 				[
 					$elm$html$Html$Attributes$class('value-label'),
-					$author$project$MuchSelect$mouseupPreventDefault(
+					$author$project$MuchSelect$mouseUpPreventDefault(
 					$author$project$MuchSelect$ToggleSelectedValueHighlight(optionValue))
 				]),
 			_List_fromArray(
@@ -19667,7 +19667,7 @@ var $author$project$MuchSelect$optionToValueHtml = F2(
 					$elm$html$Html$span,
 					_List_fromArray(
 						[
-							$author$project$MuchSelect$mouseupPreventDefault(
+							$author$project$MuchSelect$mouseUpPreventDefault(
 							$author$project$MuchSelect$DeselectOptionInternal(option)),
 							$elm$html$Html$Attributes$class('remove-option')
 						]),

--- a/dist/much-select-elm.js
+++ b/dist/much-select-elm.js
@@ -13326,14 +13326,14 @@ var $elm$html$Html$Events$custom = F2(
 			event,
 			$elm$virtual_dom$VirtualDom$Custom(decoder));
 	});
-var $author$project$MuchSelect$mousedownPreventDefault = function (message) {
+var $author$project$MuchSelect$mouseDownPreventDefault = function (message) {
 	return A2(
 		$elm$html$Html$Events$custom,
 		'mousedown',
 		$elm$json$Json$Decode$succeed(
 			{A: message, B: true, C: false}));
 };
-var $author$project$MuchSelect$mouseupPreventDefault = function (message) {
+var $author$project$MuchSelect$mouseUpPreventDefault = function (message) {
 	return A2(
 		$elm$html$Html$Events$custom,
 		'mouseup',
@@ -13493,10 +13493,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.ai(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$mouseDownPreventDefault(
 										eventHandlers.ah(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$mouseUpPreventDefault(
 										eventHandlers.ak(
 											$author$project$Option$getOptionValue(option))),
 										$author$project$MuchSelect$onClickPreventDefault(eventHandlers.a$),
@@ -13521,10 +13521,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 											$elm$html$Html$Events$onMouseLeave(
 											eventHandlers.ai(
 												$author$project$Option$getOptionValue(option))),
-											$author$project$MuchSelect$mousedownPreventDefault(
+											$author$project$MuchSelect$mouseDownPreventDefault(
 											eventHandlers.ah(
 												$author$project$Option$getOptionValue(option))),
-											$author$project$MuchSelect$mouseupPreventDefault(
+											$author$project$MuchSelect$mouseUpPreventDefault(
 											eventHandlers.ak(
 												$author$project$Option$getOptionValue(option))),
 											A2($elm$html$Html$Attributes$attribute, 'part', 'dropdown-option selected'),
@@ -13564,10 +13564,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 											$elm$html$Html$Events$onMouseLeave(
 											eventHandlers.ai(
 												$author$project$Option$getOptionValue(option))),
-											$author$project$MuchSelect$mousedownPreventDefault(
+											$author$project$MuchSelect$mouseDownPreventDefault(
 											eventHandlers.ah(
 												$author$project$Option$getOptionValue(option))),
-											$author$project$MuchSelect$mouseupPreventDefault(
+											$author$project$MuchSelect$mouseUpPreventDefault(
 											eventHandlers.ak(
 												$author$project$Option$getOptionValue(option))),
 											A2($elm$html$Html$Attributes$attribute, 'part', 'dropdown-option selected highlighted'),
@@ -13592,10 +13592,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.ai(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$mouseDownPreventDefault(
 										eventHandlers.ah(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$mouseUpPreventDefault(
 										eventHandlers.ak(
 											$author$project$Option$getOptionValue(option))),
 										A2($elm$html$Html$Attributes$attribute, 'part', 'dropdown-option highlighted'),
@@ -13628,10 +13628,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.ai(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$mouseDownPreventDefault(
 										eventHandlers.ah(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$mouseUpPreventDefault(
 										eventHandlers.ak(
 											$author$project$Option$getOptionValue(option))),
 										$author$project$MuchSelect$onClickPreventDefaultAndStopPropagation(eventHandlers.a$),
@@ -14436,7 +14436,7 @@ var $author$project$MuchSelect$valueLabelHtml = F2(
 			_List_fromArray(
 				[
 					$elm$html$Html$Attributes$class('value-label'),
-					$author$project$MuchSelect$mouseupPreventDefault(
+					$author$project$MuchSelect$mouseUpPreventDefault(
 					$author$project$MuchSelect$ToggleSelectedValueHighlight(optionValue))
 				]),
 			_List_fromArray(
@@ -14452,7 +14452,7 @@ var $author$project$MuchSelect$optionToValueHtml = F2(
 					$elm$html$Html$span,
 					_List_fromArray(
 						[
-							$author$project$MuchSelect$mouseupPreventDefault(
+							$author$project$MuchSelect$mouseUpPreventDefault(
 							$author$project$MuchSelect$DeselectOptionInternal(option)),
 							$elm$html$Html$Attributes$class('remove-option')
 						]),

--- a/dist/much-select-elm.js
+++ b/dist/much-select-elm.js
@@ -11739,7 +11739,14 @@ var $author$project$MuchSelect$update = F2(
 							$author$project$MuchSelect$ReportErrorMessage('Unable to select option'));
 					}
 				} else {
-					var updatedOptions = A2($author$project$OptionsUtilities$selectOptionInListByOptionValue, optionValue, model.b);
+					var updatedOptions = A2(
+						$author$project$OptionsUtilities$selectOptionInListByOptionValue,
+						optionValue,
+						A3(
+							$author$project$OptionsUtilities$moveHighlightedOptionDown,
+							model.a,
+							model.b,
+							A2($author$project$MuchSelect$figureOutWhichOptionsToShowInTheDropdown, model.a, model.b)));
 					var maybeNewlySelectedOption = A2($author$project$OptionsUtilities$findOptionByOptionValue, optionValue, updatedOptions);
 					if (!maybeNewlySelectedOption.$) {
 						var newlySelectedOption = maybeNewlySelectedOption.a;
@@ -13338,6 +13345,20 @@ var $author$project$MuchSelect$onClickPreventDefault = function (message) {
 		$elm$json$Json$Decode$succeed(
 			{A: message, B: true, C: false}));
 };
+var $author$project$MuchSelect$onClickPreventDefaultAndStopPropagation = function (message) {
+	return A2(
+		$elm$html$Html$Events$custom,
+		'click',
+		$elm$json$Json$Decode$succeed(
+			{A: message, B: true, C: true}));
+};
+var $author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault = function (message) {
+	return A2(
+		$elm$html$Html$Events$custom,
+		'mousedown',
+		$elm$json$Json$Decode$succeed(
+			{A: message, B: true, C: true}));
+};
 var $elm$virtual_dom$VirtualDom$Normal = function (a) {
 	return {$: 0, a: a};
 };
@@ -13359,6 +13380,13 @@ var $elm$html$Html$Events$onMouseLeave = function (msg) {
 		$elm$html$Html$Events$on,
 		'mouseleave',
 		$elm$json$Json$Decode$succeed(msg));
+};
+var $author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault = function (message) {
+	return A2(
+		$elm$html$Html$Events$custom,
+		'mouseup',
+		$elm$json$Json$Decode$succeed(
+			{A: message, B: true, C: true}));
 };
 var $author$project$Option$optionDescriptionToBool = function (optionDescription) {
 	if (!optionDescription.$) {
@@ -13477,10 +13505,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.ai(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault(
 										eventHandlers.ah(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mouseupPreventDefault(
+										$author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault(
 										eventHandlers.ak(
 											$author$project$Option$getOptionValue(option))),
 										$author$project$MuchSelect$onClickPreventDefault(eventHandlers.a$),
@@ -13575,10 +13603,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.ai(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault(
 										eventHandlers.ah(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mouseupPreventDefault(
+										$author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault(
 										eventHandlers.ak(
 											$author$project$Option$getOptionValue(option))),
 										A2($elm$html$Html$Attributes$attribute, 'part', 'dropdown-option highlighted'),
@@ -13611,13 +13639,13 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.ai(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mousedownPreventDefault(
+										$author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault(
 										eventHandlers.ah(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$mouseupPreventDefault(
+										$author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault(
 										eventHandlers.ak(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$onClickPreventDefault(eventHandlers.a$),
+										$author$project$MuchSelect$onClickPreventDefaultAndStopPropagation(eventHandlers.a$),
 										A2($elm$html$Html$Attributes$attribute, 'part', 'dropdown-option active'),
 										$elm$html$Html$Attributes$class('option'),
 										$elm$html$Html$Attributes$class('active'),
@@ -14648,20 +14676,6 @@ var $author$project$MuchSelect$defaultLoadingIndicator = A2(
 		]),
 	_List_Nil);
 var $author$project$MuchSelect$BringInputOutOfFocus = {$: 2};
-var $author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault = function (message) {
-	return A2(
-		$elm$html$Html$Events$custom,
-		'mousedown',
-		$elm$json$Json$Decode$succeed(
-			{A: message, B: true, C: true}));
-};
-var $author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault = function (message) {
-	return A2(
-		$elm$html$Html$Events$custom,
-		'mouseup',
-		$elm$json$Json$Decode$succeed(
-			{A: message, B: true, C: true}));
-};
 var $author$project$MuchSelect$dropdownIndicator = F2(
 	function (interactionState, transitioning) {
 		if (interactionState === 2) {
@@ -14721,13 +14735,6 @@ var $elm$html$Html$Events$onClick = function (msg) {
 		$elm$html$Html$Events$on,
 		'click',
 		$elm$json$Json$Decode$succeed(msg));
-};
-var $author$project$MuchSelect$onClickPreventDefaultAndStopPropagation = function (message) {
-	return A2(
-		$elm$html$Html$Events$custom,
-		'click',
-		$elm$json$Json$Decode$succeed(
-			{A: message, B: true, C: true}));
 };
 var $author$project$MuchSelect$defaultRemoveButton = A2(
 	$elm$html$Html$button,

--- a/dist/much-select-elm.js
+++ b/dist/much-select-elm.js
@@ -9670,7 +9670,8 @@ var $author$project$OptionSearcher$encodeSearchParams = F4(
 				]));
 	});
 var $author$project$OptionsUtilities$filterOptionsToShowInDropdownByOptionDisplay = function (selectionConfig) {
-	if (!selectionConfig.$) {
+	var _v0 = $author$project$SelectionMode$getSelectionMode(selectionConfig);
+	if (!_v0) {
 		return $elm$core$List$filter(
 			function (option) {
 				var _v1 = $author$project$Option$getOptionDisplay(option);
@@ -10210,7 +10211,7 @@ var $author$project$OptionsUtilities$moveHighlightedOptionDown = F3(
 			var option = maybeLowerSibling.a;
 			return A2($author$project$OptionsUtilities$highlightOptionInList, option, allOptions);
 		} else {
-			var _v1 = $elm$core$List$head(visibleOptions);
+			var _v1 = A3($author$project$OptionsUtilities$findClosestHighlightableOptionGoingDown, selectionConfig, 0, visibleOptions);
 			if (!_v1.$) {
 				var firstOption = _v1.a;
 				return A2($author$project$OptionsUtilities$highlightOptionInList, firstOption, allOptions);
@@ -11739,14 +11740,15 @@ var $author$project$MuchSelect$update = F2(
 							$author$project$MuchSelect$ReportErrorMessage('Unable to select option'));
 					}
 				} else {
+					var visibleOptions = A2($author$project$MuchSelect$figureOutWhichOptionsToShowInTheDropdown, model.a, model.b);
+					var moveHighlightedOptionDownIfThereAreOptions = F2(
+						function (selectionConfig, options) {
+							return ($elm$core$List$length(visibleOptions) > 1) ? A2($author$project$OptionsUtilities$moveHighlightedOptionDown, selectionConfig, options) : $elm$core$Basics$identity;
+						});
 					var updatedOptions = A2(
 						$author$project$OptionsUtilities$selectOptionInListByOptionValue,
 						optionValue,
-						A3(
-							$author$project$OptionsUtilities$moveHighlightedOptionDown,
-							model.a,
-							model.b,
-							A2($author$project$MuchSelect$figureOutWhichOptionsToShowInTheDropdown, model.a, model.b)));
+						A3(moveHighlightedOptionDownIfThereAreOptions, model.a, model.b, visibleOptions));
 					var maybeNewlySelectedOption = A2($author$project$OptionsUtilities$findOptionByOptionValue, optionValue, updatedOptions);
 					if (!maybeNewlySelectedOption.$) {
 						var newlySelectedOption = maybeNewlySelectedOption.a;
@@ -13352,13 +13354,6 @@ var $author$project$MuchSelect$onClickPreventDefaultAndStopPropagation = functio
 		$elm$json$Json$Decode$succeed(
 			{A: message, B: true, C: true}));
 };
-var $author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault = function (message) {
-	return A2(
-		$elm$html$Html$Events$custom,
-		'mousedown',
-		$elm$json$Json$Decode$succeed(
-			{A: message, B: true, C: true}));
-};
 var $elm$virtual_dom$VirtualDom$Normal = function (a) {
 	return {$: 0, a: a};
 };
@@ -13380,13 +13375,6 @@ var $elm$html$Html$Events$onMouseLeave = function (msg) {
 		$elm$html$Html$Events$on,
 		'mouseleave',
 		$elm$json$Json$Decode$succeed(msg));
-};
-var $author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault = function (message) {
-	return A2(
-		$elm$html$Html$Events$custom,
-		'mouseup',
-		$elm$json$Json$Decode$succeed(
-			{A: message, B: true, C: true}));
 };
 var $author$project$Option$optionDescriptionToBool = function (optionDescription) {
 	if (!optionDescription.$) {
@@ -13505,10 +13493,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.ai(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault(
+										$author$project$MuchSelect$mousedownPreventDefault(
 										eventHandlers.ah(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault(
+										$author$project$MuchSelect$mousedownPreventDefault(
 										eventHandlers.ak(
 											$author$project$Option$getOptionValue(option))),
 										$author$project$MuchSelect$onClickPreventDefault(eventHandlers.a$),
@@ -13564,7 +13552,8 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 						case 3:
 							return $elm$html$Html$text('');
 						case 5:
-							if (!selectionConfig.$) {
+							var _v2 = $author$project$SelectionMode$getSelectionMode(selectionConfig);
+							if (!_v2) {
 								return A2(
 									$elm$html$Html$div,
 									_List_fromArray(
@@ -13603,10 +13592,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.ai(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault(
+										$author$project$MuchSelect$mousedownPreventDefault(
 										eventHandlers.ah(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault(
+										$author$project$MuchSelect$mousedownPreventDefault(
 										eventHandlers.ak(
 											$author$project$Option$getOptionValue(option))),
 										A2($elm$html$Html$Attributes$attribute, 'part', 'dropdown-option highlighted'),
@@ -13639,10 +13628,10 @@ var $author$project$MuchSelect$optionToDropdownOption = F3(
 										$elm$html$Html$Events$onMouseLeave(
 										eventHandlers.ai(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault(
+										$author$project$MuchSelect$mousedownPreventDefault(
 										eventHandlers.ah(
 											$author$project$Option$getOptionValue(option))),
-										$author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault(
+										$author$project$MuchSelect$mousedownPreventDefault(
 										eventHandlers.ak(
 											$author$project$Option$getOptionValue(option))),
 										$author$project$MuchSelect$onClickPreventDefaultAndStopPropagation(eventHandlers.a$),
@@ -14676,6 +14665,20 @@ var $author$project$MuchSelect$defaultLoadingIndicator = A2(
 		]),
 	_List_Nil);
 var $author$project$MuchSelect$BringInputOutOfFocus = {$: 2};
+var $author$project$MuchSelect$onMouseDownStopPropagationAndPreventDefault = function (message) {
+	return A2(
+		$elm$html$Html$Events$custom,
+		'mousedown',
+		$elm$json$Json$Decode$succeed(
+			{A: message, B: true, C: true}));
+};
+var $author$project$MuchSelect$onMouseUpStopPropagationAndPreventDefault = function (message) {
+	return A2(
+		$elm$html$Html$Events$custom,
+		'mouseup',
+		$elm$json$Json$Decode$succeed(
+			{A: message, B: true, C: true}));
+};
 var $author$project$MuchSelect$dropdownIndicator = F2(
 	function (interactionState, transitioning) {
 		if (interactionState === 2) {

--- a/dist/much-select.js
+++ b/dist/much-select.js
@@ -683,28 +683,14 @@ class MuchSelect extends HTMLElement {
   startMuchSelectObserver() {
     // Options for the observer (which mutations to observe)
     const muchSelectMutationObserverConfig = {
-      attributes: true,
+      attributes: false,
       childList: true,
       subtree: false,
       characterData: false,
     };
 
     this._muchSelectObserver = new MutationObserver((mutationsList) => {
-      mutationsList.forEach((mutation) => {
-        if (
-          mutation.type === "attributes" &&
-          mutation.attributeName === "placeholder"
-        ) {
-          // We do no need to update the options if we are updating the placeholder.
-          return;
-        }
-        if (
-          mutation.type === "attributes" &&
-          mutation.attributeName === "loading"
-        ) {
-          // We do no need to update the options if we are updating the loading attribute.
-          return;
-        }
+      mutationsList.forEach(() => {
         this._callUpdateOptionsFromDom();
       });
     });

--- a/src/MuchSelect.elm
+++ b/src/MuchSelect.elm
@@ -474,11 +474,23 @@ update msg model =
 
                 SelectionMode.MultiSelect ->
                     let
+                        visibleOptions =
+                            figureOutWhichOptionsToShowInTheDropdown model.selectionConfig model.options
+
+                        moveHighlightedOptionDownIfThereAreOptions selectionConfig options =
+                            if List.length visibleOptions > 1 then
+                                moveHighlightedOptionDown selectionConfig
+                                    options
+
+                            else
+                                identity
+
                         updatedOptions =
                             selectOptionInListByOptionValue optionValue
-                                (moveHighlightedOptionDown model.selectionConfig
+                                (moveHighlightedOptionDownIfThereAreOptions
+                                    model.selectionConfig
                                     model.options
-                                    (figureOutWhichOptionsToShowInTheDropdown model.selectionConfig model.options)
+                                    visibleOptions
                                 )
 
                         maybeNewlySelectedOption =
@@ -2864,8 +2876,8 @@ optionToDropdownOption eventHandlers selectionConfig_ option_ =
                     div
                         [ onMouseEnter (option |> Option.getOptionValue |> eventHandlers.mouseOverMsgConstructor)
                         , onMouseLeave (option |> Option.getOptionValue |> eventHandlers.mouseOutMsgConstructor)
-                        , onMouseDownStopPropagationAndPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
-                        , onMouseUpStopPropagationAndPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
+                        , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
+                        , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
                         , onClickPreventDefault eventHandlers.noOpMsgConstructor
                         , Html.Attributes.attribute "part" "dropdown-option"
                         , class "option"
@@ -2907,8 +2919,8 @@ optionToDropdownOption eventHandlers selectionConfig_ option_ =
                     text ""
 
                 OptionSelectedHighlighted _ ->
-                    case selectionConfig of
-                        SingleSelectConfig _ _ _ ->
+                    case SelectionMode.getSelectionMode selectionConfig of
+                        SelectionMode.SingleSelect ->
                             div
                                 [ onMouseEnter (option |> Option.getOptionValue |> eventHandlers.mouseOverMsgConstructor)
                                 , onMouseLeave (option |> Option.getOptionValue |> eventHandlers.mouseOutMsgConstructor)
@@ -2922,15 +2934,15 @@ optionToDropdownOption eventHandlers selectionConfig_ option_ =
                                 ]
                                 [ labelHtml, descriptionHtml ]
 
-                        MultiSelectConfig _ _ _ ->
+                        SelectionMode.MultiSelect ->
                             text ""
 
                 OptionHighlighted ->
                     div
                         [ onMouseEnter (option |> Option.getOptionValue |> eventHandlers.mouseOverMsgConstructor)
                         , onMouseLeave (option |> Option.getOptionValue |> eventHandlers.mouseOutMsgConstructor)
-                        , onMouseDownStopPropagationAndPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
-                        , onMouseUpStopPropagationAndPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
+                        , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
+                        , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
                         , Html.Attributes.attribute "part" "dropdown-option highlighted"
                         , class "highlighted"
                         , class "option"
@@ -2951,8 +2963,8 @@ optionToDropdownOption eventHandlers selectionConfig_ option_ =
                     div
                         [ onMouseEnter (option |> Option.getOptionValue |> eventHandlers.mouseOverMsgConstructor)
                         , onMouseLeave (option |> Option.getOptionValue |> eventHandlers.mouseOutMsgConstructor)
-                        , onMouseDownStopPropagationAndPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
-                        , onMouseUpStopPropagationAndPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
+                        , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
+                        , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
                         , onClickPreventDefaultAndStopPropagation eventHandlers.noOpMsgConstructor
                         , Html.Attributes.attribute "part" "dropdown-option active"
                         , class "option"

--- a/src/MuchSelect.elm
+++ b/src/MuchSelect.elm
@@ -475,7 +475,11 @@ update msg model =
                 SelectionMode.MultiSelect ->
                     let
                         updatedOptions =
-                            selectOptionInListByOptionValue optionValue model.options
+                            selectOptionInListByOptionValue optionValue
+                                (moveHighlightedOptionDown model.selectionConfig
+                                    model.options
+                                    (figureOutWhichOptionsToShowInTheDropdown model.selectionConfig model.options)
+                                )
 
                         maybeNewlySelectedOption =
                             OptionsUtilities.findOptionByOptionValue optionValue updatedOptions
@@ -1119,7 +1123,9 @@ update msg model =
         MoveHighlightedOptionDown ->
             let
                 updatedOptions =
-                    moveHighlightedOptionDown model.selectionConfig model.options (figureOutWhichOptionsToShowInTheDropdown model.selectionConfig model.options)
+                    moveHighlightedOptionDown model.selectionConfig
+                        model.options
+                        (figureOutWhichOptionsToShowInTheDropdown model.selectionConfig model.options)
             in
             ( { model
                 | options = updatedOptions
@@ -2858,8 +2864,8 @@ optionToDropdownOption eventHandlers selectionConfig_ option_ =
                     div
                         [ onMouseEnter (option |> Option.getOptionValue |> eventHandlers.mouseOverMsgConstructor)
                         , onMouseLeave (option |> Option.getOptionValue |> eventHandlers.mouseOutMsgConstructor)
-                        , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
-                        , mouseupPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
+                        , onMouseDownStopPropagationAndPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
+                        , onMouseUpStopPropagationAndPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
                         , onClickPreventDefault eventHandlers.noOpMsgConstructor
                         , Html.Attributes.attribute "part" "dropdown-option"
                         , class "option"
@@ -2923,8 +2929,8 @@ optionToDropdownOption eventHandlers selectionConfig_ option_ =
                     div
                         [ onMouseEnter (option |> Option.getOptionValue |> eventHandlers.mouseOverMsgConstructor)
                         , onMouseLeave (option |> Option.getOptionValue |> eventHandlers.mouseOutMsgConstructor)
-                        , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
-                        , mouseupPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
+                        , onMouseDownStopPropagationAndPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
+                        , onMouseUpStopPropagationAndPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
                         , Html.Attributes.attribute "part" "dropdown-option highlighted"
                         , class "highlighted"
                         , class "option"
@@ -2945,9 +2951,9 @@ optionToDropdownOption eventHandlers selectionConfig_ option_ =
                     div
                         [ onMouseEnter (option |> Option.getOptionValue |> eventHandlers.mouseOverMsgConstructor)
                         , onMouseLeave (option |> Option.getOptionValue |> eventHandlers.mouseOutMsgConstructor)
-                        , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
-                        , mouseupPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
-                        , onClickPreventDefault eventHandlers.noOpMsgConstructor
+                        , onMouseDownStopPropagationAndPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
+                        , onMouseUpStopPropagationAndPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
+                        , onClickPreventDefaultAndStopPropagation eventHandlers.noOpMsgConstructor
                         , Html.Attributes.attribute "part" "dropdown-option active"
                         , class "option"
                         , class "active"

--- a/src/MuchSelect.elm
+++ b/src/MuchSelect.elm
@@ -2876,8 +2876,8 @@ optionToDropdownOption eventHandlers selectionConfig_ option_ =
                     div
                         [ onMouseEnter (option |> Option.getOptionValue |> eventHandlers.mouseOverMsgConstructor)
                         , onMouseLeave (option |> Option.getOptionValue |> eventHandlers.mouseOutMsgConstructor)
-                        , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
-                        , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
+                        , mouseDownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
+                        , mouseUpPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
                         , onClickPreventDefault eventHandlers.noOpMsgConstructor
                         , Html.Attributes.attribute "part" "dropdown-option"
                         , class "option"
@@ -2894,8 +2894,8 @@ optionToDropdownOption eventHandlers selectionConfig_ option_ =
                             div
                                 [ onMouseEnter (option |> Option.getOptionValue |> eventHandlers.mouseOverMsgConstructor)
                                 , onMouseLeave (option |> Option.getOptionValue |> eventHandlers.mouseOutMsgConstructor)
-                                , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
-                                , mouseupPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
+                                , mouseDownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
+                                , mouseUpPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
                                 , Html.Attributes.attribute "part" "dropdown-option selected"
                                 , class "selected"
                                 , class "option"
@@ -2924,8 +2924,8 @@ optionToDropdownOption eventHandlers selectionConfig_ option_ =
                             div
                                 [ onMouseEnter (option |> Option.getOptionValue |> eventHandlers.mouseOverMsgConstructor)
                                 , onMouseLeave (option |> Option.getOptionValue |> eventHandlers.mouseOutMsgConstructor)
-                                , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
-                                , mouseupPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
+                                , mouseDownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
+                                , mouseUpPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
                                 , Html.Attributes.attribute "part" "dropdown-option selected highlighted"
                                 , class "selected"
                                 , class "highlighted"
@@ -2941,8 +2941,8 @@ optionToDropdownOption eventHandlers selectionConfig_ option_ =
                     div
                         [ onMouseEnter (option |> Option.getOptionValue |> eventHandlers.mouseOverMsgConstructor)
                         , onMouseLeave (option |> Option.getOptionValue |> eventHandlers.mouseOutMsgConstructor)
-                        , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
-                        , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
+                        , mouseDownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
+                        , mouseUpPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
                         , Html.Attributes.attribute "part" "dropdown-option highlighted"
                         , class "highlighted"
                         , class "option"
@@ -2963,8 +2963,8 @@ optionToDropdownOption eventHandlers selectionConfig_ option_ =
                     div
                         [ onMouseEnter (option |> Option.getOptionValue |> eventHandlers.mouseOverMsgConstructor)
                         , onMouseLeave (option |> Option.getOptionValue |> eventHandlers.mouseOutMsgConstructor)
-                        , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
-                        , mousedownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
+                        , mouseDownPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseDownMsgConstructor)
+                        , mouseUpPreventDefault (option |> Option.getOptionValue |> eventHandlers.mouseUpMsgConstructor)
                         , onClickPreventDefaultAndStopPropagation eventHandlers.noOpMsgConstructor
                         , Html.Attributes.attribute "part" "dropdown-option active"
                         , class "option"
@@ -2992,7 +2992,7 @@ optionToValueHtml enableSingleItemRemoval option =
         removalHtml =
             case enableSingleItemRemoval of
                 EnableSingleItemRemoval ->
-                    span [ mouseupPreventDefault <| DeselectOptionInternal option, class "remove-option" ] [ text "" ]
+                    span [ mouseUpPreventDefault <| DeselectOptionInternal option, class "remove-option" ] [ text "" ]
 
                 DisableSingleItemRemoval ->
                     text ""
@@ -3121,7 +3121,7 @@ valueLabelHtml : String -> OptionValue -> Html Msg
 valueLabelHtml labelText optionValue =
     span
         [ class "value-label"
-        , mouseupPreventDefault
+        , mouseUpPreventDefault
             (ToggleSelectedValueHighlight optionValue)
         ]
         [ text labelText ]
@@ -3746,8 +3746,8 @@ We used to also stop propagation but that is actually a problem because that sto
 default actions from being suppressed (I think).
 
 -}
-mousedownPreventDefault : msg -> Html.Attribute msg
-mousedownPreventDefault message =
+mouseDownPreventDefault : msg -> Html.Attribute msg
+mouseDownPreventDefault message =
     Html.Events.custom "mousedown"
         (Json.Decode.succeed
             { message = message
@@ -3763,8 +3763,8 @@ We used to also stop propagation but that is actually a problem because that sto
 default actions from being suppressed (I think).
 
 -}
-mouseupPreventDefault : msg -> Html.Attribute msg
-mouseupPreventDefault message =
+mouseUpPreventDefault : msg -> Html.Attribute msg
+mouseUpPreventDefault message =
     Html.Events.custom "mouseup"
         (Json.Decode.succeed
             { message = message

--- a/src/OptionsUtilities.elm
+++ b/src/OptionsUtilities.elm
@@ -63,7 +63,10 @@ moveHighlightedOptionDown selectionConfig allOptions visibleOptions =
             highlightOptionInList option allOptions
 
         Nothing ->
-            case List.head visibleOptions of
+            -- If there is not a lower sibling to highlight, jump up to the top of the list, and see
+            --  if there is a sibling to highlight at the top of the dropdown. There might not be,
+            --  the dropdown might be empty or all the options might be selected.
+            case findClosestHighlightableOptionGoingDown selectionConfig 0 visibleOptions of
                 Just firstOption ->
                     highlightOptionInList firstOption allOptions
 
@@ -1052,8 +1055,8 @@ filterOptionsToShowInDropdown selectionConfig =
 
 filterOptionsToShowInDropdownByOptionDisplay : SelectionConfig -> List Option -> List Option
 filterOptionsToShowInDropdownByOptionDisplay selectionConfig =
-    case selectionConfig of
-        SingleSelectConfig _ _ _ ->
+    case SelectionMode.getSelectionMode selectionConfig of
+        SelectionMode.SingleSelect ->
             List.filter
                 (\option ->
                     case getOptionDisplay option of
@@ -1100,7 +1103,7 @@ filterOptionsToShowInDropdownByOptionDisplay selectionConfig =
                             True
                 )
 
-        MultiSelectConfig _ _ _ ->
+        SelectionMode.MultiSelect ->
             List.filter
                 (\option ->
                     case getOptionDisplay option of

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -683,28 +683,14 @@ class MuchSelect extends HTMLElement {
   startMuchSelectObserver() {
     // Options for the observer (which mutations to observe)
     const muchSelectMutationObserverConfig = {
-      attributes: true,
+      attributes: false,
       childList: true,
       subtree: false,
       characterData: false,
     };
 
     this._muchSelectObserver = new MutationObserver((mutationsList) => {
-      mutationsList.forEach((mutation) => {
-        if (
-          mutation.type === "attributes" &&
-          mutation.attributeName === "placeholder"
-        ) {
-          // We do no need to update the options if we are updating the placeholder.
-          return;
-        }
-        if (
-          mutation.type === "attributes" &&
-          mutation.attributeName === "loading"
-        ) {
-          // We do no need to update the options if we are updating the loading attribute.
-          return;
-        }
+      mutationsList.forEach(() => {
         this._callUpdateOptionsFromDom();
       });
     });


### PR DESCRIPTION
To see the changes here you need to be in multi select mode.

We do not need to use the mutation observer to look at attributes any more.

We have a good system for monitoring attribute changes, so we no longer should need to use the `MutationObserver` to update the options every time an attribute changes (like selected-value).

This seems to have gotten rid of at least one UI glitch.

Highlight the next option once on is selected.