### PR TITLE
selected-value attribute (in the light DOM) is being updated when it should not be

### DIFF
--- a/dist/much-select-debug.js
+++ b/dist/much-select-debug.js
@@ -369,6 +369,16 @@ class MuchSelect extends HTMLElement {
     // noinspection JSUnresolvedVariable,JSIgnoredPromiseFromCall
     this.appPromise.then((app) =>
       app.ports.lightDomChange.subscribe((lightDomChange) => {
+        const eventsOnly = booleanAttributeValueToBool(
+          this.getAttribute("events-only")
+        );
+
+        if (eventsOnly) {
+          // TODO How can this happen? This should never happen.
+          // throw new Error("We're in events only mode, what are we doing??");
+          return;
+        }
+
         if (lightDomChange.changeType === "update-selected-value") {
           const selectInputSlot = this.querySelector("[slot='select-input']");
 

--- a/dist/much-select-elm-debug.js
+++ b/dist/much-select-elm-debug.js
@@ -18226,7 +18226,12 @@ var $author$project$MuchSelect$update = F2(
 												_Utils_update(
 													model,
 													{options: newOptions})),
-											$author$project$MuchSelect$NoEffect);
+											A4(
+												$author$project$MuchSelect$makeEffectsWhenValuesChanges,
+												$author$project$SelectionMode$getEventMode(model.selectionConfig),
+												$author$project$SelectionMode$getSelectionMode(model.selectionConfig),
+												model.selectedValueEncoding,
+												$author$project$OptionsUtilities$selectedOptions(newOptions)));
 									}
 								}
 							}

--- a/dist/much-select-elm.js
+++ b/dist/much-select-elm.js
@@ -7130,7 +7130,7 @@ var $author$project$MuchSelect$init = function (flags) {
 	var selectedValueEncoding = A2(
 		$elm$core$Result$withDefault,
 		$author$project$SelectedValueEncoding$defaultSelectedValueEncoding,
-		$author$project$SelectedValueEncoding$fromMaybeString(flags.i));
+		$author$project$SelectedValueEncoding$fromMaybeString(flags.h));
 	var optionSort = A2(
 		$elm$core$Result$withDefault,
 		0,
@@ -7321,7 +7321,7 @@ var $author$project$MuchSelect$init = function (flags) {
 			p: $author$project$MuchSelect$getDebouceDelayForSearch(
 				$elm$core$List$length(optionsWithInitialValueSelectedSorted)),
 			as: 0,
-			i: selectedValueEncoding,
+			h: selectedValueEncoding,
 			a: selectionConfig,
 			a9: A2($author$project$MuchSelect$ValueCasing, 100, 45)
 		},
@@ -8576,7 +8576,7 @@ var $author$project$MuchSelect$clearAllSelectedOption = function (model) {
 					$author$project$MuchSelect$makeEffectsWhenValuesChanges,
 					$author$project$SelectionMode$getEventMode(model.a),
 					$author$project$SelectionMode$getSelectionMode(model.a),
-					model.i,
+					model.h,
 					_List_Nil),
 					deselectEventEffect,
 					focusEffect
@@ -9229,7 +9229,7 @@ var $author$project$MuchSelect$deselectOption = F2(
 						option,
 						$author$project$SelectionMode$getEventMode(model.a),
 						$author$project$SelectionMode$getSelectionMode(model.a),
-						model.i,
+						model.h,
 						$author$project$OptionsUtilities$selectedOptions(updatedOptions)),
 						A2($author$project$MuchSelect$makeEffectsForUpdatingOptionsInTheWebWorker, model.p, model.g)
 					])));
@@ -11737,7 +11737,7 @@ var $author$project$MuchSelect$update = F2(
 										newlySelectedOption,
 										$author$project$SelectionMode$getEventMode(model.a),
 										$author$project$SelectionMode$getSelectionMode(model.a),
-										model.i,
+										model.h,
 										$author$project$OptionsUtilities$selectedOptions(updatedOptions)),
 										$author$project$MuchSelect$BlurInput
 									])));
@@ -11772,7 +11772,7 @@ var $author$project$MuchSelect$update = F2(
 										newlySelectedOption,
 										$author$project$SelectionMode$getEventMode(model.a),
 										$author$project$SelectionMode$getSelectionMode(model.a),
-										model.i,
+										model.h,
 										$author$project$OptionsUtilities$selectedOptions(updatedOptions)),
 										$author$project$MuchSelect$FocusInput
 									])));
@@ -11842,7 +11842,7 @@ var $author$project$MuchSelect$update = F2(
 										$author$project$MuchSelect$makeEffectsWhenValuesChanges,
 										$author$project$SelectionMode$getEventMode(model.a),
 										$author$project$SelectionMode$getSelectionMode(model.a),
-										model.i,
+										model.h,
 										$author$project$OptionsUtilities$cleanupEmptySelectedOptions(
 											$author$project$OptionsUtilities$selectedOptions(updatedOptions))),
 										A2($author$project$MuchSelect$InputHasBeenKeyUp, valueString, 0)
@@ -11874,7 +11874,7 @@ var $author$project$MuchSelect$update = F2(
 										$author$project$MuchSelect$makeEffectsWhenValuesChanges,
 										$author$project$SelectionMode$getEventMode(model.a),
 										$author$project$SelectionMode$getSelectionMode(model.a),
-										model.i,
+										model.h,
 										$author$project$OptionsUtilities$cleanupEmptySelectedOptions(
 											$author$project$OptionsUtilities$selectedOptions(updatedOptions))),
 										A2($author$project$MuchSelect$InputHasBeenKeyUp, valueString, 2)
@@ -11904,7 +11904,7 @@ var $author$project$MuchSelect$update = F2(
 										$author$project$MuchSelect$makeEffectsWhenValuesChanges,
 										$author$project$SelectionMode$getEventMode(model.a),
 										$author$project$SelectionMode$getSelectionMode(model.a),
-										model.i,
+										model.h,
 										$author$project$OptionsUtilities$cleanupEmptySelectedOptions(
 											$author$project$OptionsUtilities$selectedOptions(updatedOptions))),
 										A2($author$project$MuchSelect$InputHasBeenKeyUp, valueString, 1)
@@ -11948,7 +11948,7 @@ var $author$project$MuchSelect$update = F2(
 								$author$project$MuchSelect$makeEffectsWhenValuesChanges,
 								$author$project$SelectionMode$getEventMode(model.a),
 								$author$project$SelectionMode$getSelectionMode(model.a),
-								model.i,
+								model.h,
 								$author$project$OptionsUtilities$selectedOptions(newOptions)));
 					} else {
 						var newOptions = A2(
@@ -11964,7 +11964,7 @@ var $author$project$MuchSelect$update = F2(
 								$author$project$MuchSelect$makeEffectsWhenValuesChanges,
 								$author$project$SelectionMode$getEventMode(model.a),
 								$author$project$SelectionMode$getSelectionMode(model.a),
-								model.i,
+								model.h,
 								$author$project$OptionsUtilities$selectedOptions(newOptions)));
 					}
 				} else {
@@ -12160,7 +12160,7 @@ var $author$project$MuchSelect$update = F2(
 									option,
 									$author$project$SelectionMode$getEventMode(model.a),
 									$author$project$SelectionMode$getSelectionMode(model.a),
-									model.i,
+									model.h,
 									$author$project$OptionsUtilities$selectedOptions(updatedOptions)),
 									A2($author$project$MuchSelect$makeEffectsForUpdatingOptionsInTheWebWorker, model.p, model.g),
 									$author$project$MuchSelect$SearchStringTouched(model.p)
@@ -12202,7 +12202,7 @@ var $author$project$MuchSelect$update = F2(
 					return _Utils_Tuple2(
 						_Utils_update(
 							model,
-							{i: selectedValueEncoding}),
+							{h: selectedValueEncoding}),
 						$author$project$MuchSelect$NoEffect);
 				} else {
 					var error = _v18.a;
@@ -12357,7 +12357,7 @@ var $author$project$MuchSelect$update = F2(
 					$author$project$MuchSelect$makeEffectsWhenValuesChanges,
 					$author$project$SelectionMode$getEventMode(model.a),
 					$author$project$SelectionMode$getSelectionMode(model.a),
-					model.i,
+					model.h,
 					$author$project$OptionsUtilities$selectedOptions(updatedOptions));
 				return _Utils_Tuple2(
 					$author$project$MuchSelect$updateModelWithChangesThatEffectTheOptionsWhenTheSearchStringChanges(
@@ -12417,7 +12417,7 @@ var $author$project$MuchSelect$update = F2(
 										newlySelectedOption,
 										$author$project$SelectionMode$getEventMode(model.a),
 										$author$project$SelectionMode$getSelectionMode(model.a),
-										model.i,
+										model.h,
 										$author$project$OptionsUtilities$selectedOptions(updatedOptions)),
 										A2($author$project$MuchSelect$makeEffectsForUpdatingOptionsInTheWebWorker, model.p, model.g),
 										$author$project$MuchSelect$BlurInput
@@ -12436,7 +12436,7 @@ var $author$project$MuchSelect$update = F2(
 										newlySelectedOption,
 										$author$project$SelectionMode$getEventMode(model.a),
 										$author$project$SelectionMode$getSelectionMode(model.a),
-										model.i,
+										model.h,
 										$author$project$OptionsUtilities$selectedOptions(updatedOptions)),
 										A2($author$project$MuchSelect$makeEffectsForUpdatingOptionsInTheWebWorker, model.p, model.g),
 										$author$project$MuchSelect$FocusInput
@@ -12542,7 +12542,7 @@ var $author$project$MuchSelect$update = F2(
 						$author$project$MuchSelect$makeEffectsWhenValuesChanges,
 						$author$project$SelectionMode$getEventMode(model.a),
 						$author$project$SelectionMode$getSelectionMode(model.a),
-						model.i,
+						model.h,
 						$author$project$OptionsUtilities$cleanupEmptySelectedOptions(
 							$author$project$OptionsUtilities$selectedOptions(updatedOptions))));
 			case 42:
@@ -12564,7 +12564,7 @@ var $author$project$MuchSelect$update = F2(
 						$author$project$MuchSelect$makeEffectsWhenValuesChanges,
 						$author$project$SelectionMode$getEventMode(model.a),
 						$author$project$SelectionMode$getSelectionMode(model.a),
-						model.i,
+						model.h,
 						$author$project$OptionsUtilities$cleanupEmptySelectedOptions(
 							$author$project$OptionsUtilities$selectedOptions(updatedOptions))));
 			case 43:
@@ -12637,7 +12637,7 @@ var $author$project$MuchSelect$update = F2(
 									$author$project$MuchSelect$makeEffectsWhenValuesChanges,
 									$author$project$SelectionMode$getEventMode(model.a),
 									$author$project$SelectionMode$getSelectionMode(model.a),
-									model.i,
+									model.h,
 									$author$project$OptionsUtilities$cleanupEmptySelectedOptions(
 										$author$project$OptionsUtilities$selectedOptions(updatedOptions))));
 						case 1:
@@ -12666,7 +12666,7 @@ var $author$project$MuchSelect$update = F2(
 									$author$project$MuchSelect$makeEffectsWhenValuesChanges,
 									$author$project$SelectionMode$getEventMode(model.a),
 									$author$project$SelectionMode$getSelectionMode(model.a),
-									model.i,
+									model.h,
 									$author$project$OptionsUtilities$cleanupEmptySelectedOptions(
 										$author$project$OptionsUtilities$selectedOptions(updatedOptions))));
 						default:
@@ -12889,7 +12889,7 @@ var $author$project$MuchSelect$update = F2(
 								}),
 							$author$project$MuchSelect$NoEffect);
 					case 'selected-value':
-						var _v39 = A2($author$project$SelectedValueEncoding$stringToValueStrings, model.i, newAttributeValue);
+						var _v39 = A2($author$project$SelectedValueEncoding$stringToValueStrings, model.h, newAttributeValue);
 						if (!_v39.$) {
 							var selectedValueStrings = _v39.a;
 							if (A2($author$project$OptionsUtilities$selectedOptionValuesAreEqual, selectedValueStrings, model.b)) {
@@ -12916,7 +12916,7 @@ var $author$project$MuchSelect$update = F2(
 													$author$project$MuchSelect$makeEffectsWhenValuesChanges,
 													$author$project$SelectionMode$getEventMode(model.a),
 													$author$project$SelectionMode$getSelectionMode(model.a),
-													model.i,
+													model.h,
 													$author$project$OptionsUtilities$selectedOptions(newOptions)));
 										}
 									} else {
@@ -12929,7 +12929,12 @@ var $author$project$MuchSelect$update = F2(
 												_Utils_update(
 													model,
 													{b: newOptions})),
-											$author$project$MuchSelect$NoEffect);
+											A4(
+												$author$project$MuchSelect$makeEffectsWhenValuesChanges,
+												$author$project$SelectionMode$getEventMode(model.a),
+												$author$project$SelectionMode$getSelectionMode(model.a),
+												model.h,
+												$author$project$OptionsUtilities$selectedOptions(newOptions)));
 									}
 								}
 							}
@@ -12946,7 +12951,7 @@ var $author$project$MuchSelect$update = F2(
 							return _Utils_Tuple2(
 								_Utils_update(
 									model,
-									{i: selectedValueEncoding}),
+									{h: selectedValueEncoding}),
 								$author$project$MuchSelect$NoEffect);
 						} else {
 							var error = _v42.a;
@@ -13038,7 +13043,7 @@ var $author$project$MuchSelect$update = F2(
 										$author$project$MuchSelect$makeEffectsWhenValuesChanges,
 										$author$project$SelectionMode$getEventMode(model.a),
 										$author$project$SelectionMode$getSelectionMode(model.a),
-										model.i,
+										model.h,
 										$author$project$OptionsUtilities$selectedOptions(updatedOptions))
 									])));
 					case 'multi-select-single-item-removal':
@@ -13099,7 +13104,7 @@ var $author$project$MuchSelect$update = F2(
 						return _Utils_Tuple2(
 							_Utils_update(
 								model,
-								{i: $author$project$SelectedValueEncoding$defaultSelectedValueEncoding}),
+								{h: $author$project$SelectedValueEncoding$defaultSelectedValueEncoding}),
 							$author$project$MuchSelect$NoEffect);
 					case 'show-dropdown-footer':
 						return _Utils_Tuple2(
@@ -13128,7 +13133,7 @@ var $author$project$MuchSelect$update = F2(
 				return _Utils_Tuple2(
 					model,
 					$author$project$MuchSelect$DumpConfigState(
-						A4($author$project$ConfigDump$encodeConfig, model.a, model.O, model.i, model.d)));
+						A4($author$project$ConfigDump$encodeConfig, model.a, model.O, model.h, model.d)));
 			default:
 				return _Utils_Tuple2(
 					model,
@@ -13147,7 +13152,7 @@ var $author$project$MuchSelect$update = F2(
 									A3(
 										$author$project$SelectedValueEncoding$rawSelectedValue,
 										$author$project$SelectionMode$getSelectionMode(model.a),
-										model.i,
+										model.h,
 										model.b))
 								]))));
 		}
@@ -15621,7 +15626,7 @@ _Platform_export({'MuchSelect':{'init':$author$project$MuchSelect$main(
 																																				$elm$json$Json$Decode$andThen,
 																																				function (allowCustomOptions) {
 																																					return $elm$json$Json$Decode$succeed(
-																																						{ba: allowCustomOptions, bb: allowMultiSelect, bg: customOptionHint, bi: disabled, bk: enableMultiSelectSingleItemRemoval, br: isEventsOnly, bt: loading, aZ: maxDropdownItems, O: optionSort, bA: optionsJson, bB: outputStyle, bC: placeholder, cG: searchStringMinimumLength, bH: selectedItemStaysInPlace, bI: selectedValue, i: selectedValueEncoding, bK: showDropdownFooter, bP: transformationAndValidationJson});
+																																						{ba: allowCustomOptions, bb: allowMultiSelect, bg: customOptionHint, bi: disabled, bk: enableMultiSelectSingleItemRemoval, br: isEventsOnly, bt: loading, aZ: maxDropdownItems, O: optionSort, bA: optionsJson, bB: outputStyle, bC: placeholder, cG: searchStringMinimumLength, bH: selectedItemStaysInPlace, bI: selectedValue, h: selectedValueEncoding, bK: showDropdownFooter, bP: transformationAndValidationJson});
 																																				},
 																																				A2($elm$json$Json$Decode$field, 'allowCustomOptions', $elm$json$Json$Decode$bool));
 																																		},
@@ -15761,7 +15766,7 @@ export const Elm = {'MuchSelect':{'init':$author$project$MuchSelect$main(
 																																				$elm$json$Json$Decode$andThen,
 																																				function (allowCustomOptions) {
 																																					return $elm$json$Json$Decode$succeed(
-																																						{ba: allowCustomOptions, bb: allowMultiSelect, bg: customOptionHint, bi: disabled, bk: enableMultiSelectSingleItemRemoval, br: isEventsOnly, bt: loading, aZ: maxDropdownItems, O: optionSort, bA: optionsJson, bB: outputStyle, bC: placeholder, cG: searchStringMinimumLength, bH: selectedItemStaysInPlace, bI: selectedValue, i: selectedValueEncoding, bK: showDropdownFooter, bP: transformationAndValidationJson});
+																																						{ba: allowCustomOptions, bb: allowMultiSelect, bg: customOptionHint, bi: disabled, bk: enableMultiSelectSingleItemRemoval, br: isEventsOnly, bt: loading, aZ: maxDropdownItems, O: optionSort, bA: optionsJson, bB: outputStyle, bC: placeholder, cG: searchStringMinimumLength, bH: selectedItemStaysInPlace, bI: selectedValue, h: selectedValueEncoding, bK: showDropdownFooter, bP: transformationAndValidationJson});
 																																				},
 																																				A2($elm$json$Json$Decode$field, 'allowCustomOptions', $elm$json$Json$Decode$bool));
 																																		},

--- a/dist/much-select-elm.js
+++ b/dist/much-select-elm.js
@@ -7019,26 +7019,6 @@ var $author$project$OptionSorting$stringToOptionSort = function (string) {
 			return $elm$core$Result$Err('Sorting the options by \"' + (string + '\" is not supported'));
 	}
 };
-var $author$project$RightSlot$ShowAddAndRemoveButtons = {$: 5};
-var $author$project$RightSlot$ShowAddButton = {$: 4};
-var $author$project$OptionValue$isEmpty = function (optionValue) {
-	if (!optionValue.$) {
-		return false;
-	} else {
-		return true;
-	}
-};
-var $author$project$RightSlot$updateRightSlotForDatalist = function (selectedOptions) {
-	var showRemoveButtons = $elm$core$List$length(selectedOptions) > 1;
-	var showAddButtons = A2(
-		$elm$core$List$any,
-		function (option) {
-			return !$author$project$OptionValue$isEmpty(
-				$author$project$Option$getOptionValue(option));
-		},
-		selectedOptions);
-	return (showAddButtons && (!showRemoveButtons)) ? $author$project$RightSlot$ShowAddButton : ((showAddButtons && showRemoveButtons) ? $author$project$RightSlot$ShowAddAndRemoveButtons : $author$project$RightSlot$ShowNothing);
-};
 var $elm$core$Result$fromMaybe = F2(
 	function (err, maybe) {
 		if (!maybe.$) {
@@ -7086,9 +7066,9 @@ var $author$project$Ports$valuesDecoder = $elm$json$Json$Decode$oneOf(
 			$elm$json$Json$Decode$list($elm$json$Json$Decode$string),
 			A2($elm$json$Json$Decode$map, $elm$core$List$singleton, $elm$json$Json$Decode$string)
 		]));
-var $author$project$SelectedValueEncoding$valuesFromFlags = F2(
+var $author$project$SelectedValueEncoding$stringToValueStrings = F2(
 	function (selectedValueEncoding, valuesString) {
-		if (valuesString === '') {
+		if ((valuesString === '') && (!selectedValueEncoding)) {
 			return $elm$core$Result$Ok(_List_Nil);
 		} else {
 			if (!selectedValueEncoding) {
@@ -7117,6 +7097,26 @@ var $author$project$SelectedValueEncoding$valuesFromFlags = F2(
 			}
 		}
 	});
+var $author$project$RightSlot$ShowAddAndRemoveButtons = {$: 5};
+var $author$project$RightSlot$ShowAddButton = {$: 4};
+var $author$project$OptionValue$isEmpty = function (optionValue) {
+	if (!optionValue.$) {
+		return false;
+	} else {
+		return true;
+	}
+};
+var $author$project$RightSlot$updateRightSlotForDatalist = function (selectedOptions) {
+	var showRemoveButtons = $elm$core$List$length(selectedOptions) > 1;
+	var showAddButtons = A2(
+		$elm$core$List$any,
+		function (option) {
+			return !$author$project$OptionValue$isEmpty(
+				$author$project$Option$getOptionValue(option));
+		},
+		selectedOptions);
+	return (showAddButtons && (!showRemoveButtons)) ? $author$project$RightSlot$ShowAddButton : ((showAddButtons && showRemoveButtons) ? $author$project$RightSlot$ShowAddAndRemoveButtons : $author$project$RightSlot$ShowNothing);
+};
 var $elm$core$Result$withDefault = F2(
 	function (def, result) {
 		if (!result.$) {
@@ -7206,7 +7206,7 @@ var $author$project$MuchSelect$init = function (flags) {
 	var selectionConfig = _v8.a;
 	var selectionConfigErrorEffect = _v8.b;
 	var _v10 = function () {
-		var _v11 = A2($author$project$SelectedValueEncoding$valuesFromFlags, selectedValueEncoding, flags.bI);
+		var _v11 = A2($author$project$SelectedValueEncoding$stringToValueStrings, selectedValueEncoding, flags.bI);
 		if (!_v11.$) {
 			var values = _v11.a;
 			return _Utils_Tuple2(values, $author$project$MuchSelect$NoEffect);
@@ -10532,6 +10532,13 @@ var $author$project$OptionsUtilities$selectHighlightedOption = F2(
 					},
 					options)));
 	});
+var $author$project$OptionsUtilities$selectedOptionValuesAreEqual = F2(
+	function (valuesAsStrings, options) {
+		return _Utils_eq(
+			$author$project$OptionsUtilities$optionsValues(
+				$author$project$OptionsUtilities$selectedOptions(options)),
+			valuesAsStrings);
+	});
 var $author$project$OptionDisplay$setAge = F2(
 	function (optionAge, optionDisplay) {
 		switch (optionDisplay.$) {
@@ -12882,16 +12889,36 @@ var $author$project$MuchSelect$update = F2(
 								}),
 							$author$project$MuchSelect$NoEffect);
 					case 'selected-value':
-						var _v39 = A2($author$project$SelectedValueEncoding$valuesFromFlags, model.i, newAttributeValue);
+						var _v39 = A2($author$project$SelectedValueEncoding$stringToValueStrings, model.i, newAttributeValue);
 						if (!_v39.$) {
 							var selectedValueStrings = _v39.a;
-							if (!selectedValueStrings.b) {
-								return $author$project$MuchSelect$clearAllSelectedOption(model);
+							if (A2($author$project$OptionsUtilities$selectedOptionValuesAreEqual, selectedValueStrings, model.b)) {
+								return _Utils_Tuple2(model, $author$project$MuchSelect$NoEffect);
 							} else {
-								if (!selectedValueStrings.b.b) {
-									var selectedValueString = selectedValueStrings.a;
-									if (selectedValueString === '') {
-										return $author$project$MuchSelect$clearAllSelectedOption(model);
+								if (!selectedValueStrings.b) {
+									return $author$project$MuchSelect$clearAllSelectedOption(model);
+								} else {
+									if (!selectedValueStrings.b.b) {
+										var selectedValueString = selectedValueStrings.a;
+										if (selectedValueString === '') {
+											return $author$project$MuchSelect$clearAllSelectedOption(model);
+										} else {
+											var newOptions = A2(
+												$author$project$OptionsUtilities$addAndSelectOptionsInOptionsListByString,
+												selectedValueStrings,
+												A2($elm$core$List$map, $author$project$Option$deselectOption, model.b));
+											return _Utils_Tuple2(
+												$author$project$MuchSelect$updateModelWithChangesThatEffectTheOptionsWhenTheSearchStringChanges(
+													_Utils_update(
+														model,
+														{b: newOptions})),
+												A4(
+													$author$project$MuchSelect$makeEffectsWhenValuesChanges,
+													$author$project$SelectionMode$getEventMode(model.a),
+													$author$project$SelectionMode$getSelectionMode(model.a),
+													model.i,
+													$author$project$OptionsUtilities$selectedOptions(newOptions)));
+										}
 									} else {
 										var newOptions = A2(
 											$author$project$OptionsUtilities$addAndSelectOptionsInOptionsListByString,
@@ -12902,24 +12929,8 @@ var $author$project$MuchSelect$update = F2(
 												_Utils_update(
 													model,
 													{b: newOptions})),
-											A4(
-												$author$project$MuchSelect$makeEffectsWhenValuesChanges,
-												$author$project$SelectionMode$getEventMode(model.a),
-												$author$project$SelectionMode$getSelectionMode(model.a),
-												model.i,
-												$author$project$OptionsUtilities$selectedOptions(newOptions)));
+											$author$project$MuchSelect$NoEffect);
 									}
-								} else {
-									var newOptions = A2(
-										$author$project$OptionsUtilities$addAndSelectOptionsInOptionsListByString,
-										selectedValueStrings,
-										A2($elm$core$List$map, $author$project$Option$deselectOption, model.b));
-									return _Utils_Tuple2(
-										$author$project$MuchSelect$updateModelWithChangesThatEffectTheOptionsWhenTheSearchStringChanges(
-											_Utils_update(
-												model,
-												{b: newOptions})),
-										$author$project$MuchSelect$NoEffect);
 								}
 							}
 						} else {

--- a/dist/much-select.js
+++ b/dist/much-select.js
@@ -369,6 +369,16 @@ class MuchSelect extends HTMLElement {
     // noinspection JSUnresolvedVariable,JSIgnoredPromiseFromCall
     this.appPromise.then((app) =>
       app.ports.lightDomChange.subscribe((lightDomChange) => {
+        const eventsOnly = booleanAttributeValueToBool(
+          this.getAttribute("events-only")
+        );
+
+        if (eventsOnly) {
+          // TODO How can this happen? This should never happen.
+          // throw new Error("We're in events only mode, what are we doing??");
+          return;
+        }
+
         if (lightDomChange.changeType === "update-selected-value") {
           const selectInputSlot = this.querySelector("[slot='select-input']");
 

--- a/src/MuchSelect.elm
+++ b/src/MuchSelect.elm
@@ -1494,50 +1494,54 @@ update msg model =
                     )
 
                 "selected-value" ->
-                    case SelectedValueEncoding.valuesFromFlags model.selectedValueEncoding newAttributeValue of
+                    case SelectedValueEncoding.stringToValueStrings model.selectedValueEncoding newAttributeValue of
                         Ok selectedValueStrings ->
-                            case selectedValueStrings of
-                                [] ->
-                                    clearAllSelectedOption model
+                            if OptionsUtilities.selectedOptionValuesAreEqual selectedValueStrings model.options then
+                                ( model, NoEffect )
 
-                                [ selectedValueString ] ->
-                                    case selectedValueString of
-                                        "" ->
-                                            clearAllSelectedOption model
+                            else
+                                case selectedValueStrings of
+                                    [] ->
+                                        clearAllSelectedOption model
 
-                                        _ ->
-                                            let
-                                                newOptions =
-                                                    model.options
-                                                        |> List.map Option.deselectOption
-                                                        |> addAndSelectOptionsInOptionsListByString
-                                                            selectedValueStrings
-                                            in
-                                            ( { model
-                                                | options = newOptions
-                                              }
-                                                |> updateModelWithChangesThatEffectTheOptionsWhenTheSearchStringChanges
-                                            , makeEffectsWhenValuesChanges
-                                                (SelectionMode.getEventMode model.selectionConfig)
-                                                (SelectionMode.getSelectionMode model.selectionConfig)
-                                                model.selectedValueEncoding
-                                                (OptionsUtilities.selectedOptions newOptions)
-                                            )
+                                    [ selectedValueString ] ->
+                                        case selectedValueString of
+                                            "" ->
+                                                clearAllSelectedOption model
 
-                                _ ->
-                                    let
-                                        newOptions =
-                                            model.options
-                                                |> List.map Option.deselectOption
-                                                |> addAndSelectOptionsInOptionsListByString
-                                                    selectedValueStrings
-                                    in
-                                    ( { model
-                                        | options = newOptions
-                                      }
-                                        |> updateModelWithChangesThatEffectTheOptionsWhenTheSearchStringChanges
-                                    , NoEffect
-                                    )
+                                            _ ->
+                                                let
+                                                    newOptions =
+                                                        model.options
+                                                            |> List.map Option.deselectOption
+                                                            |> addAndSelectOptionsInOptionsListByString
+                                                                selectedValueStrings
+                                                in
+                                                ( { model
+                                                    | options = newOptions
+                                                  }
+                                                    |> updateModelWithChangesThatEffectTheOptionsWhenTheSearchStringChanges
+                                                , makeEffectsWhenValuesChanges
+                                                    (SelectionMode.getEventMode model.selectionConfig)
+                                                    (SelectionMode.getSelectionMode model.selectionConfig)
+                                                    model.selectedValueEncoding
+                                                    (OptionsUtilities.selectedOptions newOptions)
+                                                )
+
+                                    _ ->
+                                        let
+                                            newOptions =
+                                                model.options
+                                                    |> List.map Option.deselectOption
+                                                    |> addAndSelectOptionsInOptionsListByString
+                                                        selectedValueStrings
+                                        in
+                                        ( { model
+                                            | options = newOptions
+                                          }
+                                            |> updateModelWithChangesThatEffectTheOptionsWhenTheSearchStringChanges
+                                        , NoEffect
+                                        )
 
                         Err error ->
                             ( model, ReportErrorMessage error )
@@ -3565,7 +3569,7 @@ init flags =
                 |> Result.withDefault SelectedValueEncoding.defaultSelectedValueEncoding
 
         ( initialValues, initialValueErrEffect ) =
-            case SelectedValueEncoding.valuesFromFlags selectedValueEncoding flags.selectedValue of
+            case SelectedValueEncoding.stringToValueStrings selectedValueEncoding flags.selectedValue of
                 Ok values ->
                     ( values, NoEffect )
 
@@ -3843,3 +3847,88 @@ onMouseUpStopPropagation message =
             , preventDefault = False
             }
         )
+
+
+effectToDebuggingString : Effect -> String
+effectToDebuggingString effect =
+    case effect of
+        NoEffect ->
+            "NoEffect"
+
+        Batch effects ->
+            List.map effectToDebuggingString effects |> String.join " "
+
+        FocusInput ->
+            "FocusInput"
+
+        BlurInput ->
+            "BlurInput"
+
+        InputHasBeenFocused ->
+            "InputHasBeenFocused"
+
+        InputHasBeenBlurred ->
+            "InputHasBeenBlurred"
+
+        InputHasBeenKeyUp string validationStatus ->
+            "InputHasBeenKeyUp"
+
+        SearchStringTouched float ->
+            "SearchStringTouched"
+
+        UpdateOptionsInWebWorker ->
+            "UpdateOptionsInWebWorker"
+
+        SearchOptionsWithWebWorker value ->
+            "SearchOptionsWithWebWorker"
+
+        ReportValueChanged value ->
+            "ReportValueChanged"
+
+        ValueCleared ->
+            "ValueCleared"
+
+        InvalidValue value ->
+            "InvalidValue"
+
+        CustomOptionSelected strings ->
+            "CustomOptionSelected"
+
+        ReportOptionSelected value ->
+            "ReportOptionSelected"
+
+        ReportOptionDeselected value ->
+            "ReportOptionDeselected"
+
+        OptionsUpdated bool ->
+            "OptionsUpdated"
+
+        SendCustomValidationRequest ( string, int ) ->
+            "SendCustomValidationRequest"
+
+        ReportErrorMessage string ->
+            "ReportErrorMessage"
+
+        ReportReady ->
+            "ReportReady"
+
+        ReportInitialValueSet value ->
+            "ReportInitialValueSet"
+
+        FetchOptionsFromDom ->
+            "FetchOptionsFromDom"
+
+        ScrollDownToElement string ->
+            "ScrollDownToElement"
+
+        ReportAllOptions value ->
+            "ReportAllOptions"
+
+        DumpConfigState value ->
+            "DumpConfigState"
+
+        DumpSelectedValues value ->
+            "DumpSelectedValues"
+
+        ChangeTheLightDom lightDomChange ->
+            "ChangeTheLightDom"

--- a/src/MuchSelect.elm
+++ b/src/MuchSelect.elm
@@ -1540,7 +1540,11 @@ update msg model =
                                             | options = newOptions
                                           }
                                             |> updateModelWithChangesThatEffectTheOptionsWhenTheSearchStringChanges
-                                        , NoEffect
+                                        , makeEffectsWhenValuesChanges
+                                            (SelectionMode.getEventMode model.selectionConfig)
+                                            (SelectionMode.getSelectionMode model.selectionConfig)
+                                            model.selectedValueEncoding
+                                            (OptionsUtilities.selectedOptions newOptions)
                                         )
 
                         Err error ->

--- a/src/OptionsUtilities.elm
+++ b/src/OptionsUtilities.elm
@@ -1503,6 +1503,11 @@ selectOptionsInOptionsListByString strings options =
         |> deselectEveryOptionExceptOptionsInList optionsToSelect
 
 
+selectedOptionValuesAreEqual : List String -> List Option -> Bool
+selectedOptionValuesAreEqual valuesAsStrings options =
+    (options |> selectedOptions |> optionsValues) == valuesAsStrings
+
+
 addAndSelectOptionsInOptionsListByString : List String -> List Option -> List Option
 addAndSelectOptionsInOptionsListByString strings options =
     let

--- a/src/SelectedValueEncoding.elm
+++ b/src/SelectedValueEncoding.elm
@@ -59,9 +59,9 @@ toString selectedValueEncoding =
             "json"
 
 
-valuesFromFlags : SelectedValueEncoding -> String -> Result String (List String)
-valuesFromFlags selectedValueEncoding valuesString =
-    if valuesString == "" then
+stringToValueStrings : SelectedValueEncoding -> String -> Result String (List String)
+stringToValueStrings selectedValueEncoding valuesString =
+    if valuesString == "" && selectedValueEncoding == CommaSeperated then
         Ok []
 
     else

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -369,6 +369,16 @@ class MuchSelect extends HTMLElement {
     // noinspection JSUnresolvedVariable,JSIgnoredPromiseFromCall
     this.appPromise.then((app) =>
       app.ports.lightDomChange.subscribe((lightDomChange) => {
+        const eventsOnly = booleanAttributeValueToBool(
+          this.getAttribute("events-only")
+        );
+
+        if (eventsOnly) {
+          // TODO How can this happen? This should never happen.
+          // throw new Error("We're in events only mode, what are we doing??");
+          return;
+        }
+
         if (lightDomChange.changeType === "update-selected-value") {
           const selectInputSlot = this.querySelector("[slot='select-input']");
 

--- a/tests/Attributes/SelectedValue.elm
+++ b/tests/Attributes/SelectedValue.elm
@@ -1,0 +1,548 @@
+module Attributes.SelectedValue exposing (suite)
+
+import Expect
+import Json.Decode
+import Json.Encode
+import LightDomChange exposing (LightDomChange(..))
+import List.Extra
+import MuchSelect exposing (Flags)
+import Option
+import Ports exposing (optionsEncoder)
+import ProgramTest exposing (ProgramTest)
+import SimulatedEffect.Cmd
+import SimulatedEffect.Ports
+import Test exposing (Test, describe, test)
+
+
+flags : Flags
+flags =
+    { isEventsOnly = False
+    , selectedValue = "fifi"
+    , selectedValueEncoding = Nothing
+    , placeholder = ( True, "" )
+    , customOptionHint = Nothing
+    , allowMultiSelect = False
+    , outputStyle = "customHtml"
+    , enableMultiSelectSingleItemRemoval = False
+    , optionsJson = "[]"
+    , optionSort = ""
+    , loading = False
+    , maxDropdownItems = Just "10"
+    , disabled = False
+    , allowCustomOptions = False
+    , selectedItemStaysInPlace = True
+    , searchStringMinimumLength = Nothing
+    , showDropdownFooter = False
+    , transformationAndValidationJson = ""
+    }
+
+
+simulatedEffects : MuchSelect.Effect -> ProgramTest.SimulatedEffect MuchSelect.Msg
+simulatedEffects effect =
+    case effect of
+        MuchSelect.NoEffect ->
+            SimulatedEffect.Cmd.none
+
+        MuchSelect.Batch effects ->
+            SimulatedEffect.Cmd.batch (List.map simulatedEffects effects)
+
+        MuchSelect.FocusInput ->
+            SimulatedEffect.Ports.send "focusInput" (Json.Encode.object [])
+
+        MuchSelect.BlurInput ->
+            SimulatedEffect.Ports.send "blurInput" (Json.Encode.object [])
+
+        MuchSelect.InputHasBeenFocused ->
+            SimulatedEffect.Ports.send "inputFocused" (Json.Encode.object [])
+
+        MuchSelect.InputHasBeenBlurred ->
+            SimulatedEffect.Ports.send "inputBlurred" (Json.Encode.object [])
+
+        MuchSelect.InputHasBeenKeyUp string _ ->
+            SimulatedEffect.Ports.send "inputKeyUp" (Json.Encode.string string)
+
+        MuchSelect.SearchStringTouched _ ->
+            SimulatedEffect.Cmd.none
+
+        MuchSelect.UpdateOptionsInWebWorker ->
+            SimulatedEffect.Ports.send "updateOptionsInWebWorker" (Json.Encode.object [])
+
+        MuchSelect.SearchOptionsWithWebWorker value ->
+            SimulatedEffect.Ports.send "searchOptionsWithWebWorker" value
+
+        MuchSelect.ReportValueChanged value ->
+            SimulatedEffect.Ports.send "valueChanged" value
+
+        MuchSelect.ValueCleared ->
+            SimulatedEffect.Ports.send "valueCleared" (Json.Encode.object [])
+
+        MuchSelect.InvalidValue value ->
+            SimulatedEffect.Ports.send "invalidValue" value
+
+        MuchSelect.CustomOptionSelected strings ->
+            SimulatedEffect.Ports.send "invalidValue" (Json.Encode.list Json.Encode.string strings)
+
+        MuchSelect.ReportOptionSelected value ->
+            SimulatedEffect.Ports.send "optionSelected" value
+
+        MuchSelect.ReportOptionDeselected value ->
+            SimulatedEffect.Ports.send "optionDeselected" value
+
+        MuchSelect.OptionsUpdated bool ->
+            SimulatedEffect.Ports.send "optionDeselected" (Json.Encode.bool bool)
+
+        MuchSelect.SendCustomValidationRequest ( string, int ) ->
+            SimulatedEffect.Ports.send "sendCustomValidationRequest"
+                (Json.Encode.list identity
+                    [ Json.Encode.string string
+                    , Json.Encode.int int
+                    ]
+                )
+
+        MuchSelect.ReportErrorMessage string ->
+            SimulatedEffect.Ports.send "errorMessage" (Json.Encode.string string)
+
+        MuchSelect.ReportReady ->
+            SimulatedEffect.Ports.send "ready" (Json.Encode.object [])
+
+        MuchSelect.ReportInitialValueSet value ->
+            SimulatedEffect.Ports.send "initialValueSet" value
+
+        MuchSelect.FetchOptionsFromDom ->
+            SimulatedEffect.Ports.send "ready" (Json.Encode.object [])
+
+        MuchSelect.ScrollDownToElement string ->
+            SimulatedEffect.Ports.send "scrollDropdownToElement" (Json.Encode.string string)
+
+        MuchSelect.ReportAllOptions value ->
+            SimulatedEffect.Ports.send "allOptions" value
+
+        MuchSelect.DumpConfigState value ->
+            SimulatedEffect.Ports.send "dumpConfigState" value
+
+        MuchSelect.DumpSelectedValues value ->
+            SimulatedEffect.Ports.send "dumpSelectedValues" value
+
+        MuchSelect.ChangeTheLightDom lightDomChange ->
+            SimulatedEffect.Ports.send "lightDomChange" (LightDomChange.encode lightDomChange)
+
+
+simulateSubscriptions : MuchSelect.Model -> ProgramTest.SimulatedSub MuchSelect.Msg
+simulateSubscriptions _ =
+    SimulatedEffect.Ports.subscribe "attributeChanged"
+        (Json.Decode.map2
+            Tuple.pair
+            (Json.Decode.index 0 Json.Decode.string)
+            (Json.Decode.index 1 Json.Decode.string)
+        )
+        MuchSelect.AttributeChanged
+
+
+element =
+    ProgramTest.createElement
+        { init = MuchSelect.init
+        , update = MuchSelect.update
+        , view = MuchSelect.view
+        }
+        |> ProgramTest.withSimulatedEffects simulatedEffects
+        |> ProgramTest.withSimulatedSubscriptions simulateSubscriptions
+
+
+start : Flags -> ProgramTest MuchSelect.Model MuchSelect.Msg MuchSelect.Effect
+start flags_ =
+    element
+        |> ProgramTest.start
+            flags_
+
+
+suite : Test
+suite =
+    describe "When the selected-value attribute is updated"
+        [ describe "in single select mode"
+            [ test "and it's the same value as before we should do nothing" <|
+                \() ->
+                    start flags
+                        |> ProgramTest.simulateIncomingPort
+                            "attributeChanged"
+                            (Json.Encode.list Json.Encode.string [ "selected-value", "fifi" ])
+                        |> ProgramTest.expectLastEffect
+                            (\effect ->
+                                case effect of
+                                    MuchSelect.NoEffect ->
+                                        Expect.pass
+
+                                    _ ->
+                                        Expect.fail "We should have done nothing"
+                            )
+            , test "to a new value we should get effects to report the changed value" <|
+                \() ->
+                    start flags
+                        |> ProgramTest.simulateIncomingPort
+                            "attributeChanged"
+                            (Json.Encode.list Json.Encode.string [ "selected-value", "pilot" ])
+                        |> ProgramTest.expectLastEffect
+                            (\lastEffect ->
+                                case lastEffect of
+                                    MuchSelect.Batch lastEffects ->
+                                        case List.head lastEffects of
+                                            Just firstLastEffect ->
+                                                Expect.equal firstLastEffect
+                                                    (MuchSelect.ReportValueChanged
+                                                        (optionsEncoder
+                                                            [ Option.newOption "pilot" Nothing
+                                                                |> Option.selectOption 0
+                                                            ]
+                                                        )
+                                                    )
+
+                                            Nothing ->
+                                                Expect.fail "Nothing in the batch of effects"
+
+                                    _ ->
+                                        Expect.fail "Should have been a batch"
+                            )
+            , test "to a new value we should get effects to report the changed value and update the light DOM" <|
+                \() ->
+                    start flags
+                        |> ProgramTest.simulateIncomingPort
+                            "attributeChanged"
+                            (Json.Encode.list Json.Encode.string [ "selected-value", "pilot" ])
+                        |> ProgramTest.expectLastEffect
+                            (\lastEffect ->
+                                case lastEffect of
+                                    MuchSelect.Batch lastEffects ->
+                                        case List.Extra.last lastEffects of
+                                            Just lastLastEffect ->
+                                                case lastLastEffect of
+                                                    MuchSelect.ChangeTheLightDom change ->
+                                                        case change of
+                                                            UpdateSelectedValue value ->
+                                                                Expect.equal
+                                                                    value
+                                                                    (Json.Encode.object
+                                                                        [ ( "rawValue"
+                                                                          , Json.Encode.string "pilot"
+                                                                          )
+                                                                        , ( "value"
+                                                                          , Json.Encode.string "pilot"
+                                                                          )
+                                                                        , ( "selectionMode"
+                                                                          , Json.Encode.string "single-select"
+                                                                          )
+                                                                        ]
+                                                                    )
+
+                                                            _ ->
+                                                                Expect.fail "This should have been an update to the selected value"
+
+                                                    _ ->
+                                                        Expect.fail "This should have been a change to the light DOM"
+
+                                            Nothing ->
+                                                Expect.fail "There should have been something in the list of effects"
+
+                                    _ ->
+                                        Expect.fail "The effect should have been a batch"
+                            )
+            ]
+        , describe "in multi select mode"
+            [ describe "with json encoding"
+                [ test "and it's the same value as before we should do nothing" <|
+                    \() ->
+                        start
+                            { flags
+                                | allowMultiSelect = True
+                                , selectedValueEncoding = Just "json"
+                                , selectedValue = "%5B%22fifi%22%5D"
+                            }
+                            |> ProgramTest.simulateIncomingPort
+                                "attributeChanged"
+                                (Json.Encode.list Json.Encode.string [ "selected-value", "%5B%22fifi%22%5D" ])
+                            |> ProgramTest.expectLastEffect
+                                (\effect ->
+                                    case effect of
+                                        MuchSelect.NoEffect ->
+                                            Expect.pass
+
+                                        _ ->
+                                            Expect.fail "We should have done nothing"
+                                )
+                , test "to a new value we should get effects to report the changed value" <|
+                    \() ->
+                        start
+                            { flags
+                                | allowMultiSelect = True
+                                , selectedValueEncoding = Just "json"
+                                , selectedValue = "%5B%22fifi%22%5D"
+                            }
+                            |> ProgramTest.simulateIncomingPort
+                                "attributeChanged"
+                                (Json.Encode.list Json.Encode.string [ "selected-value", "%5B%22pilot%22%5D" ])
+                            |> ProgramTest.expectLastEffect
+                                (\lastEffect ->
+                                    case lastEffect of
+                                        MuchSelect.Batch lastEffects ->
+                                            case List.head lastEffects of
+                                                Just firstLastEffect ->
+                                                    Expect.equal firstLastEffect
+                                                        (MuchSelect.ReportValueChanged
+                                                            (optionsEncoder
+                                                                [ Option.newOption "pilot" Nothing
+                                                                    |> Option.selectOption 0
+                                                                ]
+                                                            )
+                                                        )
+
+                                                Nothing ->
+                                                    Expect.fail "Nothing in the batch of effects"
+
+                                        _ ->
+                                            Expect.fail "Should have been a batch"
+                                )
+                , test "to a new value we should get effects to report the changed value and update the light DOM" <|
+                    \() ->
+                        start
+                            { flags
+                                | allowMultiSelect = True
+                                , selectedValueEncoding = Just "json"
+                                , selectedValue = "%5B%22fifi%22%5D"
+                            }
+                            |> ProgramTest.simulateIncomingPort
+                                "attributeChanged"
+                                (Json.Encode.list Json.Encode.string [ "selected-value", "%5B%22pilot%22%5D" ])
+                            |> ProgramTest.expectLastEffect
+                                (\lastEffect ->
+                                    case lastEffect of
+                                        MuchSelect.Batch lastEffects ->
+                                            case List.Extra.last lastEffects of
+                                                Just lastLastEffect ->
+                                                    case lastLastEffect of
+                                                        MuchSelect.ChangeTheLightDom change ->
+                                                            case change of
+                                                                UpdateSelectedValue value ->
+                                                                    Expect.equal
+                                                                        value
+                                                                        (Json.Encode.object
+                                                                            [ ( "rawValue"
+                                                                              , Json.Encode.string "%5B%22pilot%22%5D"
+                                                                              )
+                                                                            , ( "value"
+                                                                              , Json.Encode.list Json.Encode.string [ "pilot" ]
+                                                                              )
+                                                                            , ( "selectionMode"
+                                                                              , Json.Encode.string "multi-select"
+                                                                              )
+                                                                            ]
+                                                                        )
+
+                                                                _ ->
+                                                                    Expect.fail "This should have been an update to the selected value"
+
+                                                        _ ->
+                                                            Expect.fail "This should have been a change to the light DOM"
+
+                                                Nothing ->
+                                                    Expect.fail "There should have been something in the list of effects"
+
+                                        _ ->
+                                            Expect.fail "The effect should have been a batch"
+                                )
+                , describe "in events only mode"
+                    [ test "and it's the same value as before we should do nothing" <|
+                        \() ->
+                            start
+                                { flags
+                                    | allowMultiSelect = True
+                                    , selectedValueEncoding = Just "json"
+                                    , selectedValue = "%5B%22fifi%22%5D"
+                                    , isEventsOnly = True
+                                }
+                                |> ProgramTest.simulateIncomingPort
+                                    "attributeChanged"
+                                    (Json.Encode.list Json.Encode.string [ "selected-value", "%5B%22fifi%22%5D" ])
+                                |> ProgramTest.expectLastEffect
+                                    (\effect ->
+                                        case effect of
+                                            MuchSelect.NoEffect ->
+                                                Expect.pass
+
+                                            _ ->
+                                                Expect.fail "We should have done nothing"
+                                    )
+                    , test "with multiple values selected and it's the same selected value as before we should do nothing" <|
+                        \() ->
+                            start
+                                { flags
+                                    | allowMultiSelect = True
+                                    , selectedValueEncoding = Just "json"
+                                    , selectedValue = "%5B%22fifi%22%2C%22pilot%22%5D"
+                                    , isEventsOnly = True
+                                }
+                                |> ProgramTest.simulateIncomingPort
+                                    "attributeChanged"
+                                    (Json.Encode.list Json.Encode.string [ "selected-value", "%5B%22fifi%22%2C%22pilot%22%5D" ])
+                                |> ProgramTest.expectLastEffect
+                                    (\effect ->
+                                        case effect of
+                                            MuchSelect.NoEffect ->
+                                                Expect.pass
+
+                                            _ ->
+                                                Expect.fail "We should have done nothing"
+                                    )
+                    , test "to a new selected value we should get an effect to report the changed value" <|
+                        \() ->
+                            start
+                                { flags
+                                    | allowMultiSelect = True
+                                    , selectedValueEncoding = Just "json"
+                                    , selectedValue = "%5B%22fifi%22%5D"
+                                    , isEventsOnly = True
+                                }
+                                |> ProgramTest.simulateIncomingPort
+                                    "attributeChanged"
+                                    (Json.Encode.list Json.Encode.string [ "selected-value", "%5B%22pilot%22%5D" ])
+                                |> ProgramTest.expectLastEffect
+                                    (\lastEffect ->
+                                        case lastEffect of
+                                            MuchSelect.Batch lastEffects ->
+                                                case List.head lastEffects of
+                                                    Just firstLastEffect ->
+                                                        Expect.equal firstLastEffect
+                                                            (MuchSelect.ReportValueChanged
+                                                                (optionsEncoder
+                                                                    [ Option.newOption "pilot" Nothing
+                                                                        |> Option.selectOption 0
+                                                                    ]
+                                                                )
+                                                            )
+
+                                                    Nothing ->
+                                                        Expect.fail "Nothing in the batch of effects"
+
+                                            _ ->
+                                                Expect.fail "Should have been a batch"
+                                    )
+                    , test "to a new selected value we should get not get effects to change the light DOM" <|
+                        \() ->
+                            start
+                                { flags
+                                    | allowMultiSelect = True
+                                    , selectedValueEncoding = Just "json"
+                                    , selectedValue = "%5B%22fifi%22%5D"
+                                    , isEventsOnly = True
+                                }
+                                |> ProgramTest.simulateIncomingPort
+                                    "attributeChanged"
+                                    (Json.Encode.list Json.Encode.string [ "selected-value", "%5B%22pilot%22%5D" ])
+                                |> ProgramTest.expectLastEffect
+                                    (\lastEffect ->
+                                        case lastEffect of
+                                            MuchSelect.Batch lastEffects ->
+                                                List.filter
+                                                    (\lastEffect_ ->
+                                                        case lastEffect_ of
+                                                            MuchSelect.ChangeTheLightDom _ ->
+                                                                True
+
+                                                            _ ->
+                                                                False
+                                                    )
+                                                    lastEffects
+                                                    |> List.isEmpty
+                                                    |> Expect.equal True
+
+                                            _ ->
+                                                Expect.fail "The effect should have been a batch"
+                                    )
+                    ]
+                ]
+            , describe "with comma encoding"
+                [ test "and it's the same selected value as before we get no effects" <|
+                    \() ->
+                        start { flags | allowMultiSelect = True }
+                            |> ProgramTest.simulateIncomingPort
+                                "attributeChanged"
+                                (Json.Encode.list Json.Encode.string [ "selected-value", "fifi" ])
+                            |> ProgramTest.expectLastEffect
+                                (\effect ->
+                                    case effect of
+                                        MuchSelect.NoEffect ->
+                                            Expect.pass
+
+                                        _ ->
+                                            Expect.fail "We should have done nothing"
+                                )
+                , test "to a new selected value we should get an effect to report the changed value" <|
+                    \() ->
+                        start { flags | allowMultiSelect = True }
+                            |> ProgramTest.simulateIncomingPort
+                                "attributeChanged"
+                                (Json.Encode.list Json.Encode.string [ "selected-value", "pilot" ])
+                            |> ProgramTest.expectLastEffect
+                                (\lastEffect ->
+                                    case lastEffect of
+                                        MuchSelect.Batch lastEffects ->
+                                            case List.head lastEffects of
+                                                Just firstLastEffect ->
+                                                    Expect.equal firstLastEffect
+                                                        (MuchSelect.ReportValueChanged
+                                                            (optionsEncoder
+                                                                [ Option.newOption "pilot" Nothing
+                                                                    |> Option.selectOption 0
+                                                                ]
+                                                            )
+                                                        )
+
+                                                Nothing ->
+                                                    Expect.fail "Nothing in the batch of effects"
+
+                                        _ ->
+                                            Expect.fail "Should have been a batch"
+                                )
+                , test "to a new selected value we should get an effect update the light DOM" <|
+                    \() ->
+                        start { flags | allowMultiSelect = True }
+                            |> ProgramTest.simulateIncomingPort
+                                "attributeChanged"
+                                (Json.Encode.list Json.Encode.string [ "selected-value", "pilot" ])
+                            |> ProgramTest.expectLastEffect
+                                (\lastEffect ->
+                                    case lastEffect of
+                                        MuchSelect.Batch lastEffects ->
+                                            case List.Extra.last lastEffects of
+                                                Just lastLastEffect ->
+                                                    case lastLastEffect of
+                                                        MuchSelect.ChangeTheLightDom change ->
+                                                            case change of
+                                                                UpdateSelectedValue value ->
+                                                                    Expect.equal
+                                                                        value
+                                                                        (Json.Encode.object
+                                                                            [ ( "rawValue"
+                                                                              , Json.Encode.string "pilot"
+                                                                              )
+                                                                            , ( "value"
+                                                                              , Json.Encode.list Json.Encode.string [ "pilot" ]
+                                                                              )
+                                                                            , ( "selectionMode"
+                                                                              , Json.Encode.string "multi-select"
+                                                                              )
+                                                                            ]
+                                                                        )
+
+                                                                _ ->
+                                                                    Expect.fail "This should have been an update to the selected value"
+
+                                                        _ ->
+                                                            Expect.fail "This should have been a change to the light DOM"
+
+                                                Nothing ->
+                                                    Expect.fail "There should have been something in the list of effects"
+
+                                        _ ->
+                                            Expect.fail "The effect should have been a batch"
+                                )
+                ]
+            ]
+        ]


### PR DESCRIPTION
I was running into a bug while testing in the segment builder in the monolith.

It took a lot of testing to figure out what was going on. But, somehow something was triggering a `lightDomChange` when the the `<much-select>` _should_ have been in `events-only` mode. To solve this problem I added an extra check in the JavaScript for the `events-only` attribute. I should not need to do this here, but I don't think it's going to do any harm.

*There is still a mystery about how this can happen*. I wouldn't not have thought there would have been a way to do this, but I guess there is.

I also added a bunch more elm tests. I though (among other things) there might be a bug in how I was handling things when the `attributeChanged` port got called. I don't think that's the issue any more. I'm keeping the tests anyway, because they look like good tests to have.

I also found a case where the `selected-value` attribute is changed and we should be emitting events and we were not.

I also changed the behavior, so even if we get a change to the `selected-value` attribute, if ti doesn't _actually_ change any things, then don't do anything.

I also changed it so, if the `selected-value` attribute is set to an empty string, and the `<much-select>` is using json encoding it throws an error and does not change anything.