### PR TITLE
Add the ability to specify a custom option hint to the Elm demo.

### DIFF
--- a/dist/much-select-debug.js
+++ b/dist/much-select-debug.js
@@ -985,8 +985,16 @@ class MuchSelect extends HTMLElement {
     flags.maxDropdownItems = this.getAttribute("max-dropdown-items");
 
     if (this.hasAttribute("allow-custom-options")) {
-      flags.customOptionHint = this.getAttribute("allow-custom-options");
-      flags.allowCustomOptions = true;
+      if (this.getAttribute("allow-custom-options") === "true") {
+        flags.customOptionHint = null;
+        flags.allowCustomOptions = true;
+      } else if (this.getAttribute("allow-custom-options") === "false") {
+        flags.customOptionHint = this.getAttribute("allow-custom-options");
+        flags.allowCustomOptions = false;
+      } else {
+        flags.customOptionHint = this.getAttribute("allow-custom-options");
+        flags.allowCustomOptions = true;
+      }
     } else {
       flags.customOptionHint = null;
       flags.allowCustomOptions = false;

--- a/dist/much-select-elm-debug.js
+++ b/dist/much-select-elm-debug.js
@@ -17579,10 +17579,15 @@ var $author$project$MuchSelect$update = F2(
 				var canAddCustomOptions = _v21.a;
 				var customOptionHint = _v21.b;
 				var maybeCustomOptionHint = function () {
-					if (customOptionHint === '') {
-						return $elm$core$Maybe$Nothing;
-					} else {
-						return $elm$core$Maybe$Just(customOptionHint);
+					switch (customOptionHint) {
+						case '':
+							return $elm$core$Maybe$Nothing;
+						case 'true':
+							return $elm$core$Maybe$Nothing;
+						case 'false':
+							return $elm$core$Maybe$Nothing;
+						default:
+							return $elm$core$Maybe$Just(customOptionHint);
 					}
 				}();
 				return _Utils_Tuple2(

--- a/dist/much-select-elm-debug.js
+++ b/dist/much-select-elm-debug.js
@@ -18020,6 +18020,14 @@ var $author$project$MuchSelect$update = F2(
 											selectionConfig: A3($author$project$SelectionMode$setAllowCustomOptionsWithBool, false, $elm$core$Maybe$Nothing, model.selectionConfig)
 										}),
 									$author$project$MuchSelect$NoEffect);
+							case 'true':
+								return _Utils_Tuple2(
+									_Utils_update(
+										model,
+										{
+											selectionConfig: A3($author$project$SelectionMode$setAllowCustomOptionsWithBool, true, $elm$core$Maybe$Nothing, model.selectionConfig)
+										}),
+									$author$project$MuchSelect$NoEffect);
 							default:
 								var customOptionHint = newAttributeValue;
 								return _Utils_Tuple2(

--- a/dist/much-select-elm.js
+++ b/dist/much-select-elm.js
@@ -12282,10 +12282,15 @@ var $author$project$MuchSelect$update = F2(
 				var canAddCustomOptions = _v21.a;
 				var customOptionHint = _v21.b;
 				var maybeCustomOptionHint = function () {
-					if (customOptionHint === '') {
-						return $elm$core$Maybe$Nothing;
-					} else {
-						return $elm$core$Maybe$Just(customOptionHint);
+					switch (customOptionHint) {
+						case '':
+							return $elm$core$Maybe$Nothing;
+						case 'true':
+							return $elm$core$Maybe$Nothing;
+						case 'false':
+							return $elm$core$Maybe$Nothing;
+						default:
+							return $elm$core$Maybe$Just(customOptionHint);
 					}
 				}();
 				return _Utils_Tuple2(

--- a/dist/much-select-elm.js
+++ b/dist/much-select-elm.js
@@ -12723,6 +12723,14 @@ var $author$project$MuchSelect$update = F2(
 											a: A3($author$project$SelectionMode$setAllowCustomOptionsWithBool, false, $elm$core$Maybe$Nothing, model.a)
 										}),
 									$author$project$MuchSelect$NoEffect);
+							case 'true':
+								return _Utils_Tuple2(
+									_Utils_update(
+										model,
+										{
+											a: A3($author$project$SelectionMode$setAllowCustomOptionsWithBool, true, $elm$core$Maybe$Nothing, model.a)
+										}),
+									$author$project$MuchSelect$NoEffect);
 							default:
 								var customOptionHint = newAttributeValue;
 								return _Utils_Tuple2(

--- a/dist/much-select.js
+++ b/dist/much-select.js
@@ -985,8 +985,16 @@ class MuchSelect extends HTMLElement {
     flags.maxDropdownItems = this.getAttribute("max-dropdown-items");
 
     if (this.hasAttribute("allow-custom-options")) {
-      flags.customOptionHint = this.getAttribute("allow-custom-options");
-      flags.allowCustomOptions = true;
+      if (this.getAttribute("allow-custom-options") === "true") {
+        flags.customOptionHint = null;
+        flags.allowCustomOptions = true;
+      } else if (this.getAttribute("allow-custom-options") === "false") {
+        flags.customOptionHint = this.getAttribute("allow-custom-options");
+        flags.allowCustomOptions = false;
+      } else {
+        flags.customOptionHint = this.getAttribute("allow-custom-options");
+        flags.allowCustomOptions = true;
+      }
     } else {
       flags.customOptionHint = null;
       flags.allowCustomOptions = false;

--- a/src/Demo.elm
+++ b/src/Demo.elm
@@ -56,6 +56,7 @@ type alias Flags =
 
 type alias Model =
     { allowCustomOptions : Bool
+    , customOptionsHint : Maybe String
     , allowMultiSelect : Bool
     , outputStyle : String
     , customValidationResult : ValidationResult
@@ -139,6 +140,7 @@ type Msg
     | ToggleValidation Validator Bool
     | ToggleDisabled Bool
     | ChangeSelectedValue (List MuchSelectValue)
+    | ChangeCustomOptionsHint String
 
 
 main : Program Flags Model Msg
@@ -154,6 +156,7 @@ main =
 init : Flags -> ( Model, Cmd Msg )
 init _ =
     ( { allowCustomOptions = False
+      , customOptionsHint = Nothing
       , allowMultiSelect = False
       , outputStyle = "custom-html"
       , customValidationResult = NothingToValidate
@@ -312,6 +315,14 @@ update msg model =
         ChangeSelectedValue muchSelectValues ->
             ( { model | selectedValues = muchSelectValues }, Cmd.none )
 
+        ChangeCustomOptionsHint string ->
+            case string of
+                "" ->
+                    ( { model | customOptionsHint = Nothing }, Cmd.none )
+
+                _ ->
+                    ( { model | customOptionsHint = Just string }, Cmd.none )
+
 
 lordOfTheRingsCharacterToDemoOption : LordOfTheRingsCharacter -> DemoOption
 lordOfTheRingsCharacterToDemoOption character =
@@ -442,10 +453,15 @@ onCustomValidationRequest =
         )
 
 
-allowCustomOptionsAttribute : Bool -> Attribute msg
-allowCustomOptionsAttribute bool =
+allowCustomOptionsAttribute : Bool -> Maybe String -> Attribute msg
+allowCustomOptionsAttribute bool maybeHint =
     if bool then
-        attribute "allow-custom-options" ""
+        case maybeHint of
+            Just hint ->
+                attribute "allow-custom-options" hint
+
+            Nothing ->
+                attribute "allow-custom-options" ""
 
     else
         Html.Attributes.Extra.empty
@@ -533,7 +549,7 @@ view model =
             [ attribute "events-only" ""
             , selectedValueAttribute model.selectedValueEncoding model.selectedValues
             , selectedValueEncodingAttribute model.selectedValueEncoding
-            , allowCustomOptionsAttribute model.allowCustomOptions
+            , allowCustomOptionsAttribute model.allowCustomOptions model.customOptionsHint
             , multiSelectAttribute model.allowMultiSelect
             , outputStyleAttribute model.outputStyle
             , placeholderAttribute model.placeholder
@@ -813,6 +829,22 @@ view model =
                     ]
                     []
                 , label [ for "minimum-length-checkbox" ] [ text "Minimum Length" ]
+                ]
+            , fieldset []
+                [ legend []
+                    [ text "Custom Option Hint"
+                    ]
+                , label
+                    [ for "custom-option-hint" ]
+                    [ text "Custom Option Hint: " ]
+                , input
+                    [ type_ "text"
+                    , name "custom-option-hint"
+                    , id "custom-option-input"
+                    , disabled (not model.allowCustomOptions)
+                    , onChange ChangeCustomOptionsHint
+                    ]
+                    []
                 ]
             ]
         ]

--- a/src/MuchSelect.elm
+++ b/src/MuchSelect.elm
@@ -915,6 +915,12 @@ update msg model =
                         "" ->
                             Nothing
 
+                        "true" ->
+                            Nothing
+
+                        "false" ->
+                            Nothing
+
                         _ ->
                             Just customOptionHint
             in

--- a/src/MuchSelect.elm
+++ b/src/MuchSelect.elm
@@ -1349,6 +1349,17 @@ update msg model =
                             , NoEffect
                             )
 
+                        "true" ->
+                            ( { model
+                                | selectionConfig =
+                                    SelectionMode.setAllowCustomOptionsWithBool
+                                        True
+                                        Nothing
+                                        model.selectionConfig
+                              }
+                            , NoEffect
+                            )
+
                         customOptionHint ->
                             ( { model
                                 | selectionConfig =

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -985,8 +985,16 @@ class MuchSelect extends HTMLElement {
     flags.maxDropdownItems = this.getAttribute("max-dropdown-items");
 
     if (this.hasAttribute("allow-custom-options")) {
-      flags.customOptionHint = this.getAttribute("allow-custom-options");
-      flags.allowCustomOptions = true;
+      if (this.getAttribute("allow-custom-options") === "true") {
+        flags.customOptionHint = null;
+        flags.allowCustomOptions = true;
+      } else if (this.getAttribute("allow-custom-options") === "false") {
+        flags.customOptionHint = this.getAttribute("allow-custom-options");
+        flags.allowCustomOptions = false;
+      } else {
+        flags.customOptionHint = this.getAttribute("allow-custom-options");
+        flags.allowCustomOptions = true;
+      }
     } else {
       flags.customOptionHint = null;
       flags.allowCustomOptions = false;


### PR DESCRIPTION
When testing in the monolith, we need to be able to support setting the `allow-custom-options` attribute to `true`, with out `true` being the actual hint.