### PR TITLE
also dispatch input event on selected-value change

### DIFF
--- a/src/much-select.js
+++ b/src/much-select.js
@@ -427,6 +427,9 @@ class MuchSelect extends HTMLElement {
             hiddenValueInput.dispatchEvent(
               new Event("change", { bubbles: true })
             );
+            hiddenValueInput.dispatchEvent(
+              new Event("input", { bubbles: true })
+            );
           }
 
           this.startMuchSelectObserver();


### PR DESCRIPTION
Follow up to: https://github.com/DripEmail/much-select-elm/pull/226

Some parts of the app make use of the `change` event while other parts use the `input`, canonical the light DOM normally dispatches both, so we should follow suit. 