### PR TITLE
trim search  string

### DIFF
--- a/src/OptionSearcher.elm
+++ b/src/OptionSearcher.elm
@@ -69,9 +69,14 @@ search string option =
 updateSearchResultInOption : SearchString -> Option -> Option
 updateSearchResultInOption searchString option =
     let
+        -- if the searchString has a trailing space it doesn't match with certain types of options
+        trimedSearchString =
+            SearchString.toString searchString
+                |> String.trim
+
         searchResult : OptionSearchResult
         searchResult =
-            search (SearchString.toString searchString) option
+            search trimedSearchString option
 
         labelTokens =
             tokenize (option |> Option.getOptionLabel |> optionLabelToString) searchResult.labelMatch


### PR DESCRIPTION
Addresses: [GG-556](https://dripcom.atlassian.net/browse/GG-556)

TLDR;

just trim the end of the search strings solves this bug and keeps looking correctly if you then add more characters 

[GG-556]: https://dripcom.atlassian.net/browse/GG-556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ