### PR TITLE
custom selected options always get a selected value index of 0

### DIFF
--- a/dist/much-select-elm-debug.js
+++ b/dist/much-select-elm-debug.js
@@ -12743,22 +12743,17 @@ var $elm_community$list_extra$List$Extra$mapAccuml = F3(
 			accFinal,
 			$elm$core$List$reverse(generatedList));
 	});
-var $author$project$OptionList$selectOption = F2(
-	function (optionToSelect, options) {
-		var optionValue = $author$project$Option$getOptionValue(optionToSelect);
-		var notLessThanZero = function (index) {
-			return (index < 0) ? 0 : index;
-		};
-		var selectionIndex = notLessThanZero(
-			$author$project$Option$getOptionSelectedIndex(optionToSelect));
-		return A3($author$project$OptionList$selectOptionByOptionValueWithIndex, selectionIndex, optionValue, options);
-	});
 var $author$project$OptionList$selectOptions = F2(
 	function (optionsToSelect, optionList) {
 		var helper = F2(
 			function (newOptions, optionToSelect) {
+				var selectionIndex = ($author$project$Option$getOptionSelectedIndex(optionToSelect) < 0) ? 0 : $author$project$Option$getOptionSelectedIndex(optionToSelect);
 				return _Utils_Tuple2(
-					A2($author$project$OptionList$selectOption, optionToSelect, newOptions),
+					A3(
+						$author$project$OptionList$selectOptionByOptionValueWithIndex,
+						selectionIndex,
+						$author$project$Option$getOptionValue(optionToSelect),
+						newOptions),
 					_List_Nil);
 			});
 		return A3($elm_community$list_extra$List$Extra$mapAccuml, helper, optionList, optionsToSelect).a;
@@ -16586,6 +16581,41 @@ var $author$project$OptionList$clearAnyUnselectedCustomOptions = function (optio
 		},
 		optionsList);
 };
+var $author$project$OptionList$foldl = F3(
+	function (_function, b, optionList) {
+		switch (optionList.$) {
+			case 'FancyOptionList':
+				var options = optionList.a;
+				return A3($elm$core$List$foldl, _function, b, options);
+			case 'DatalistOptionList':
+				var options = optionList.a;
+				return A3($elm$core$List$foldl, _function, b, options);
+			default:
+				var options = optionList.a;
+				return A3($elm$core$List$foldl, _function, b, options);
+		}
+	});
+var $author$project$OptionList$selectOptionByOptionValue = F2(
+	function (value, list) {
+		var nextSelectedIndex = A3(
+			$author$project$OptionList$foldl,
+			F2(
+				function (selectedOption, highestIndex) {
+					return (_Utils_cmp(
+						$author$project$Option$getOptionSelectedIndex(selectedOption),
+						highestIndex) > 0) ? $author$project$Option$getOptionSelectedIndex(selectedOption) : highestIndex;
+				}),
+			-1,
+			list) + 1;
+		return A3($author$project$OptionList$selectOptionByOptionValueWithIndex, nextSelectedIndex, value, list);
+	});
+var $author$project$OptionList$selectOption = F2(
+	function (optionToSelect, options) {
+		return A2(
+			$author$project$OptionList$selectOptionByOptionValue,
+			$author$project$Option$getOptionValue(optionToSelect),
+			options);
+	});
 var $author$project$OptionList$selectSingleOption = F2(
 	function (option, optionList) {
 		return A2(
@@ -16629,34 +16659,6 @@ var $author$project$OptionList$selectHighlightedOption = F2(
 							},
 							optionList))));
 		}
-	});
-var $author$project$OptionList$foldl = F3(
-	function (_function, b, optionList) {
-		switch (optionList.$) {
-			case 'FancyOptionList':
-				var options = optionList.a;
-				return A3($elm$core$List$foldl, _function, b, options);
-			case 'DatalistOptionList':
-				var options = optionList.a;
-				return A3($elm$core$List$foldl, _function, b, options);
-			default:
-				var options = optionList.a;
-				return A3($elm$core$List$foldl, _function, b, options);
-		}
-	});
-var $author$project$OptionList$selectOptionByOptionValue = F2(
-	function (value, list) {
-		var nextSelectedIndex = A3(
-			$author$project$OptionList$foldl,
-			F2(
-				function (selectedOption, highestIndex) {
-					return (_Utils_cmp(
-						$author$project$Option$getOptionSelectedIndex(selectedOption),
-						highestIndex) > 0) ? $author$project$Option$getOptionSelectedIndex(selectedOption) : highestIndex;
-				}),
-			-1,
-			list) + 1;
-		return A3($author$project$OptionList$selectOptionByOptionValueWithIndex, nextSelectedIndex, value, list);
 	});
 var $author$project$OptionList$selectedOptionValuesAreEqual = F2(
 	function (valuesAsStrings, options) {

--- a/dist/much-select-elm.js
+++ b/dist/much-select-elm.js
@@ -7376,22 +7376,17 @@ var $elm_community$list_extra$List$Extra$mapAccuml = F3(
 			accFinal,
 			$elm$core$List$reverse(generatedList));
 	});
-var $author$project$OptionList$selectOption = F2(
-	function (optionToSelect, options) {
-		var optionValue = $author$project$Option$getOptionValue(optionToSelect);
-		var notLessThanZero = function (index) {
-			return (index < 0) ? 0 : index;
-		};
-		var selectionIndex = notLessThanZero(
-			$author$project$Option$getOptionSelectedIndex(optionToSelect));
-		return A3($author$project$OptionList$selectOptionByOptionValueWithIndex, selectionIndex, optionValue, options);
-	});
 var $author$project$OptionList$selectOptions = F2(
 	function (optionsToSelect, optionList) {
 		var helper = F2(
 			function (newOptions, optionToSelect) {
+				var selectionIndex = ($author$project$Option$getOptionSelectedIndex(optionToSelect) < 0) ? 0 : $author$project$Option$getOptionSelectedIndex(optionToSelect);
 				return _Utils_Tuple2(
-					A2($author$project$OptionList$selectOption, optionToSelect, newOptions),
+					A3(
+						$author$project$OptionList$selectOptionByOptionValueWithIndex,
+						selectionIndex,
+						$author$project$Option$getOptionValue(optionToSelect),
+						newOptions),
 					_List_Nil);
 			});
 		return A3($elm_community$list_extra$List$Extra$mapAccuml, helper, optionList, optionsToSelect).a;
@@ -11286,6 +11281,41 @@ var $author$project$OptionList$clearAnyUnselectedCustomOptions = function (optio
 		},
 		optionsList);
 };
+var $author$project$OptionList$foldl = F3(
+	function (_function, b, optionList) {
+		switch (optionList.$) {
+			case 0:
+				var options = optionList.a;
+				return A3($elm$core$List$foldl, _function, b, options);
+			case 1:
+				var options = optionList.a;
+				return A3($elm$core$List$foldl, _function, b, options);
+			default:
+				var options = optionList.a;
+				return A3($elm$core$List$foldl, _function, b, options);
+		}
+	});
+var $author$project$OptionList$selectOptionByOptionValue = F2(
+	function (value, list) {
+		var nextSelectedIndex = A3(
+			$author$project$OptionList$foldl,
+			F2(
+				function (selectedOption, highestIndex) {
+					return (_Utils_cmp(
+						$author$project$Option$getOptionSelectedIndex(selectedOption),
+						highestIndex) > 0) ? $author$project$Option$getOptionSelectedIndex(selectedOption) : highestIndex;
+				}),
+			-1,
+			list) + 1;
+		return A3($author$project$OptionList$selectOptionByOptionValueWithIndex, nextSelectedIndex, value, list);
+	});
+var $author$project$OptionList$selectOption = F2(
+	function (optionToSelect, options) {
+		return A2(
+			$author$project$OptionList$selectOptionByOptionValue,
+			$author$project$Option$getOptionValue(optionToSelect),
+			options);
+	});
 var $author$project$OptionList$selectSingleOption = F2(
 	function (option, optionList) {
 		return A2(
@@ -11329,34 +11359,6 @@ var $author$project$OptionList$selectHighlightedOption = F2(
 							},
 							optionList))));
 		}
-	});
-var $author$project$OptionList$foldl = F3(
-	function (_function, b, optionList) {
-		switch (optionList.$) {
-			case 0:
-				var options = optionList.a;
-				return A3($elm$core$List$foldl, _function, b, options);
-			case 1:
-				var options = optionList.a;
-				return A3($elm$core$List$foldl, _function, b, options);
-			default:
-				var options = optionList.a;
-				return A3($elm$core$List$foldl, _function, b, options);
-		}
-	});
-var $author$project$OptionList$selectOptionByOptionValue = F2(
-	function (value, list) {
-		var nextSelectedIndex = A3(
-			$author$project$OptionList$foldl,
-			F2(
-				function (selectedOption, highestIndex) {
-					return (_Utils_cmp(
-						$author$project$Option$getOptionSelectedIndex(selectedOption),
-						highestIndex) > 0) ? $author$project$Option$getOptionSelectedIndex(selectedOption) : highestIndex;
-				}),
-			-1,
-			list) + 1;
-		return A3($author$project$OptionList$selectOptionByOptionValueWithIndex, nextSelectedIndex, value, list);
 	});
 var $author$project$OptionList$selectedOptionValuesAreEqual = F2(
 	function (valuesAsStrings, options) {

--- a/src/OptionList.elm
+++ b/src/OptionList.elm
@@ -504,22 +504,7 @@ Pick a selection index that is the same as the selection index of the option.
 -}
 selectOption : Option -> OptionList -> OptionList
 selectOption optionToSelect options =
-    let
-        notLessThanZero index =
-            if index < 0 then
-                0
-
-            else
-                index
-
-        selectionIndex =
-            Option.getOptionSelectedIndex optionToSelect
-                |> notLessThanZero
-
-        optionValue =
-            Option.getOptionValue optionToSelect
-    in
-    selectOptionByOptionValueWithIndex selectionIndex optionValue options
+    selectOptionByOptionValue (Option.getOptionValue optionToSelect) options
 
 
 {-| Look through the list of options, if we find one that matches the given option value
@@ -576,14 +561,6 @@ selectOptionByOptionValueWithIndex index optionValue optionList =
     map
         (\option_ ->
             if Option.optionEqualsOptionValue optionValue option_ then
-                --CustomOption _ _ _ _ ->
-                --    case value of
-                --        OptionValue valueStr ->
-                --            Option.selectOption nextSelectedIndex option_
-                --                |> setLabelWithString valueStr Nothing
-                --
-                --        EmptyOptionValue ->
-                --            Option.selectOption nextSelectedIndex option_
                 option_ |> Option.select index
 
             else
@@ -597,12 +574,32 @@ selectOptionIByValueStringWithIndex int string optionList =
     selectOptionByOptionValueWithIndex int (OptionValue.stringToOptionValue string) optionList
 
 
+{-| Select all the options in a "list" of options in an OptionList.
+
+While we do this we're going to try to be smart with the selection index. We're going to get the selection index from the option.
+
+If it's -1 then we're going to use 0. If it's 0 or greater we're going to use that.
+
+-}
 selectOptions : List Option -> OptionList -> OptionList
 selectOptions optionsToSelect optionList =
     let
         helper : OptionList -> Option -> ( OptionList, List Option )
         helper newOptions optionToSelect =
-            ( selectOption optionToSelect newOptions, [] )
+            let
+                selectionIndex =
+                    if Option.getOptionSelectedIndex optionToSelect < 0 then
+                        0
+
+                    else
+                        Option.getOptionSelectedIndex optionToSelect
+            in
+            ( selectOptionByOptionValueWithIndex
+                selectionIndex
+                (Option.getOptionValue optionToSelect)
+                newOptions
+            , []
+            )
     in
     List.Extra.mapAccuml helper optionList optionsToSelect
         |> Tuple.first

--- a/tests/Option/CustomOptions.elm
+++ b/tests/Option/CustomOptions.elm
@@ -65,24 +65,12 @@ emptyFancyList =
     test_newFancyOptionList []
 
 
-optionToTuple : Option -> ( String, Bool )
-optionToTuple option =
-    Tuple.pair (Option.getOptionValueAsString option) (Option.isSelected option)
-
-
-assertEqualLists : OptionList -> OptionList -> Expectation
-assertEqualLists optionListA optionListB =
-    Expect.equalLists
-        (optionListA |> OptionList.getOptions |> List.map optionToTuple)
-        (optionListB |> OptionList.getOptions |> List.map optionToTuple)
-
-
 suite : Test
 suite =
     describe "Custom options"
         [ test "should be able to remove all the unselected custom options" <|
             \_ ->
-                assertEqualLists
+                Expect.equal
                     (test_newFancyOptionList
                         [ birchWood
                         , select 0 cutCopper


### PR DESCRIPTION
To fix this I had to change up some of the logic and that broke some unit tests having to do with merging options. I think I solved by by making the `selectOptions` function a bit more complicated. It's behavior seems pretty sensible so I think it's OK.

But I can't help but wonder if the options that are coming in to be selected should already have a selected index on them.