### PR TITLE
Adding the `focus()` function to `MuchSelect`.

### DIFF
--- a/dist/much-select-debug.js
+++ b/dist/much-select-debug.js
@@ -38,7 +38,9 @@ const buildOptionsFromSelectElement = (selectElement) => {
       value = optionElement.innerText;
     }
     const option = { value };
-    if (optionElement.hasAttribute("id")) {
+    if (optionElement.hasAttribute("data-part")) {
+      option.part = optionElement.getAttribute("data-part").trim();
+    } else if (optionElement.hasAttribute("id")) {
       option.part = optionElement.getAttribute("id").trim();
     } else {
       option.part = dasherize(option.value.trim());
@@ -610,13 +612,7 @@ class MuchSelect extends HTMLElement {
       app.ports.focusInput.subscribe(() => {
         // This port is here because we need to be able to call the focus method
         //  which is something we can not do from inside Elm.
-        window.requestAnimationFrame(() => {
-          const inputFilterElement =
-            this.shadowRoot.getElementById("input-filter");
-          if (inputFilterElement) {
-            this.shadowRoot.getElementById("input-filter").focus();
-          }
-        });
+        this.focus();
       }),
     );
 
@@ -1995,6 +1991,15 @@ class MuchSelect extends HTMLElement {
         // Maybe this can get garbage collected, we should not need it again.
         //  not that we have a filter worker we don't need any more.
         this._filterWorkerOptionsCache = null;
+      }
+    });
+  }
+
+  focus() {
+    window.requestAnimationFrame(() => {
+      const inputFilterElement = this.shadowRoot.getElementById("input-filter");
+      if (inputFilterElement) {
+        this.shadowRoot.getElementById("input-filter").focus();
       }
     });
   }

--- a/dist/much-select-debug.js
+++ b/dist/much-select-debug.js
@@ -219,6 +219,8 @@ class MuchSelect extends HTMLElement {
   constructor() {
     super();
 
+    this._isReady = false;
+
     /**
      * Used in the CSS and elsewhere to determine what the
      *  minimum width should be.
@@ -381,6 +383,7 @@ class MuchSelect extends HTMLElement {
         window.requestAnimationFrame(() => {
           this.dispatchEvent(new CustomEvent("ready", { bubbles: true }));
           this.dispatchEvent(new CustomEvent("muchSelectReady"));
+          this._isReady = true;
         });
       }),
     );
@@ -2002,6 +2005,20 @@ class MuchSelect extends HTMLElement {
         this.shadowRoot.getElementById("input-filter").focus();
       }
     });
+  }
+
+  async isReady(count = 0) {
+    // return if this._isReady is true, if not wait a bit and then check 3 more times.
+    if (this._isReady) {
+      return true;
+    }
+    if (count < 3) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 100);
+      });
+      return this.isReady(count + 1);
+    }
+    return false;
   }
 }
 

--- a/dist/much-select.js
+++ b/dist/much-select.js
@@ -38,7 +38,9 @@ const buildOptionsFromSelectElement = (selectElement) => {
       value = optionElement.innerText;
     }
     const option = { value };
-    if (optionElement.hasAttribute("id")) {
+    if (optionElement.hasAttribute("data-part")) {
+      option.part = optionElement.getAttribute("data-part").trim();
+    } else if (optionElement.hasAttribute("id")) {
       option.part = optionElement.getAttribute("id").trim();
     } else {
       option.part = dasherize(option.value.trim());
@@ -610,13 +612,7 @@ class MuchSelect extends HTMLElement {
       app.ports.focusInput.subscribe(() => {
         // This port is here because we need to be able to call the focus method
         //  which is something we can not do from inside Elm.
-        window.requestAnimationFrame(() => {
-          const inputFilterElement =
-            this.shadowRoot.getElementById("input-filter");
-          if (inputFilterElement) {
-            this.shadowRoot.getElementById("input-filter").focus();
-          }
-        });
+        this.focus();
       }),
     );
 
@@ -1995,6 +1991,15 @@ class MuchSelect extends HTMLElement {
         // Maybe this can get garbage collected, we should not need it again.
         //  not that we have a filter worker we don't need any more.
         this._filterWorkerOptionsCache = null;
+      }
+    });
+  }
+
+  focus() {
+    window.requestAnimationFrame(() => {
+      const inputFilterElement = this.shadowRoot.getElementById("input-filter");
+      if (inputFilterElement) {
+        this.shadowRoot.getElementById("input-filter").focus();
       }
     });
   }

--- a/dist/much-select.js
+++ b/dist/much-select.js
@@ -219,6 +219,8 @@ class MuchSelect extends HTMLElement {
   constructor() {
     super();
 
+    this._isReady = false;
+
     /**
      * Used in the CSS and elsewhere to determine what the
      *  minimum width should be.
@@ -381,6 +383,7 @@ class MuchSelect extends HTMLElement {
         window.requestAnimationFrame(() => {
           this.dispatchEvent(new CustomEvent("ready", { bubbles: true }));
           this.dispatchEvent(new CustomEvent("muchSelectReady"));
+          this._isReady = true;
         });
       }),
     );
@@ -2002,6 +2005,20 @@ class MuchSelect extends HTMLElement {
         this.shadowRoot.getElementById("input-filter").focus();
       }
     });
+  }
+
+  async isReady(count = 0) {
+    // return if this._isReady is true, if not wait a bit and then check 3 more times.
+    if (this._isReady) {
+      return true;
+    }
+    if (count < 3) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 100);
+      });
+      return this.isReady(count + 1);
+    }
+    return false;
   }
 }
 

--- a/examples/focus-on-demand.html
+++ b/examples/focus-on-demand.html
@@ -1,0 +1,23 @@
+<div id="focus-on-demand">
+  <h3>Single Select - <code>blurOrUnfocusedValueChanged</code> Event</h3>
+  <much-select>
+    <select slot="select-input">
+      <option value="111">Grass Pea</option>
+      <option value="222">Velvet Bean</option>
+      <option value="333">Sword Bean</option>
+      <option value="444">Soybean</option>
+    </select>
+  </much-select>
+  <br>
+  <button>Focus 👀</button>
+
+  <script>
+    window.addEventListener("load", () => {
+      document
+        .querySelector("#focus-on-demand button")
+        .addEventListener("click", () => {
+          document.querySelector("#focus-on-demand much-select").focus();
+        });
+    });
+  </script>
+</div>

--- a/site/events.html
+++ b/site/events.html
@@ -64,6 +64,10 @@
     <div class="example">
       <div id="single-select-blur-or-unfocused-value-change"></div>
     </div>
+
+    <div class="example">
+      <div id="focus-on-demand"></div>
+    </div>
   </div>
 
   <footer></footer>

--- a/soupault.toml
+++ b/soupault.toml
@@ -299,6 +299,11 @@ widget = "include"
 file = "examples/events-only-mode.html"
 selector = ".example #events-only-mode"
 
+[widgets.focus-on-dedmand]
+widget = "include"
+file = "examples/focus-on-demand.html"
+selector = ".example #focus-on-demand"
+
 [widgets.hidden-input-json-encoding-slot]
 widget = "include"
 file = "examples/hidden-input-json-encoding-slot.html"

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -610,13 +610,7 @@ class MuchSelect extends HTMLElement {
       app.ports.focusInput.subscribe(() => {
         // This port is here because we need to be able to call the focus method
         //  which is something we can not do from inside Elm.
-        window.requestAnimationFrame(() => {
-          const inputFilterElement =
-            this.shadowRoot.getElementById("input-filter");
-          if (inputFilterElement) {
-            this.shadowRoot.getElementById("input-filter").focus();
-          }
-        });
+        this.focus();
       }),
     );
 
@@ -1995,6 +1989,15 @@ class MuchSelect extends HTMLElement {
         // Maybe this can get garbage collected, we should not need it again.
         //  not that we have a filter worker we don't need any more.
         this._filterWorkerOptionsCache = null;
+      }
+    });
+  }
+
+  focus() {
+    window.requestAnimationFrame(() => {
+      const inputFilterElement = this.shadowRoot.getElementById("input-filter");
+      if (inputFilterElement) {
+        this.shadowRoot.getElementById("input-filter").focus();
       }
     });
   }

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -217,6 +217,8 @@ class MuchSelect extends HTMLElement {
   constructor() {
     super();
 
+    this._isReady = false;
+
     /**
      * Used in the CSS and elsewhere to determine what the
      *  minimum width should be.
@@ -379,6 +381,7 @@ class MuchSelect extends HTMLElement {
         window.requestAnimationFrame(() => {
           this.dispatchEvent(new CustomEvent("ready", { bubbles: true }));
           this.dispatchEvent(new CustomEvent("muchSelectReady"));
+          this._isReady = true;
         });
       }),
     );
@@ -2000,6 +2003,20 @@ class MuchSelect extends HTMLElement {
         this.shadowRoot.getElementById("input-filter").focus();
       }
     });
+  }
+
+  async isReady(count = 0) {
+    // return if this._isReady is true, if not wait a bit and then check 3 more times.
+    if (this._isReady) {
+      return true;
+    }
+    if (count < 3) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 100);
+      });
+      return this.isReady(count + 1);
+    }
+    return false;
   }
 }
 


### PR DESCRIPTION
Add an example that shows how to call `focus()`, which will focus the `<much-select>`.