### PR TITLE
Comma in values fix

### DIFF
--- a/dist/much-select-elm-debug.js
+++ b/dist/much-select-elm-debug.js
@@ -13121,8 +13121,8 @@ var $author$project$Ports$valuesDecoder = $elm$json$Json$Decode$oneOf(
 			$elm$json$Json$Decode$list($elm$json$Json$Decode$string),
 			A2($elm$json$Json$Decode$map, $elm$core$List$singleton, $elm$json$Json$Decode$string)
 		]));
-var $author$project$SelectedValueEncoding$stringToValueStrings = F2(
-	function (selectedValueEncoding, valuesString) {
+var $author$project$SelectedValueEncoding$stringToValueStrings = F3(
+	function (config, selectedValueEncoding, valuesString) {
 		if ((valuesString === '') && _Utils_eq(selectedValueEncoding, $author$project$SelectedValueEncoding$CommaSeperated)) {
 			return $elm$core$Result$Ok(_List_Nil);
 		} else {
@@ -13130,8 +13130,14 @@ var $author$project$SelectedValueEncoding$stringToValueStrings = F2(
 				return $elm$core$Result$Ok(_List_Nil);
 			} else {
 				if (selectedValueEncoding.$ === 'CommaSeperated') {
-					return $elm$core$Result$Ok(
-						A2($elm$core$String$split, ',', valuesString));
+					if (config.$ === 'SingleSelectConfig') {
+						return $elm$core$Result$Ok(
+							_List_fromArray(
+								[valuesString]));
+					} else {
+						return $elm$core$Result$Ok(
+							A2($elm$core$String$split, ',', valuesString));
+					}
 				} else {
 					return A2(
 						$elm$core$Result$andThen,
@@ -13275,7 +13281,7 @@ var $author$project$MuchSelect$init = function (flags) {
 	var selectionConfig = _v10.a;
 	var selectionConfigErrorEffect = _v10.b;
 	var _v12 = function () {
-		var _v13 = A2($author$project$SelectedValueEncoding$stringToValueStrings, selectedValueEncoding, flags.selectedValue);
+		var _v13 = A3($author$project$SelectedValueEncoding$stringToValueStrings, selectionConfig, selectedValueEncoding, flags.selectedValue);
 		if (_v13.$ === 'Ok') {
 			var values = _v13.a;
 			return _Utils_Tuple2(values, $author$project$MuchSelect$NoEffect);
@@ -19460,7 +19466,7 @@ var $author$project$MuchSelect$update = F2(
 								}),
 							$author$project$MuchSelect$NoEffect);
 					case 'selected-value':
-						var _v43 = A2($author$project$SelectedValueEncoding$stringToValueStrings, model.selectedValueEncoding, newAttributeValue);
+						var _v43 = A3($author$project$SelectedValueEncoding$stringToValueStrings, model.selectionConfig, model.selectedValueEncoding, newAttributeValue);
 						if (_v43.$ === 'Ok') {
 							var selectedValueStrings = _v43.a;
 							if (A2($author$project$OptionList$selectedOptionValuesAreEqual, selectedValueStrings, model.options)) {

--- a/dist/much-select-elm.js
+++ b/dist/much-select-elm.js
@@ -7763,8 +7763,8 @@ var $author$project$Ports$valuesDecoder = $elm$json$Json$Decode$oneOf(
 			$elm$json$Json$Decode$list($elm$json$Json$Decode$string),
 			A2($elm$json$Json$Decode$map, $elm$core$List$singleton, $elm$json$Json$Decode$string)
 		]));
-var $author$project$SelectedValueEncoding$stringToValueStrings = F2(
-	function (selectedValueEncoding, valuesString) {
+var $author$project$SelectedValueEncoding$stringToValueStrings = F3(
+	function (config, selectedValueEncoding, valuesString) {
 		if ((valuesString === '') && (!selectedValueEncoding)) {
 			return $elm$core$Result$Ok(_List_Nil);
 		} else {
@@ -7772,8 +7772,14 @@ var $author$project$SelectedValueEncoding$stringToValueStrings = F2(
 				return $elm$core$Result$Ok(_List_Nil);
 			} else {
 				if (!selectedValueEncoding) {
-					return $elm$core$Result$Ok(
-						A2($elm$core$String$split, ',', valuesString));
+					if (!config.$) {
+						return $elm$core$Result$Ok(
+							_List_fromArray(
+								[valuesString]));
+					} else {
+						return $elm$core$Result$Ok(
+							A2($elm$core$String$split, ',', valuesString));
+					}
 				} else {
 					return A2(
 						$elm$core$Result$andThen,
@@ -7917,7 +7923,7 @@ var $author$project$MuchSelect$init = function (flags) {
 	var selectionConfig = _v10.a;
 	var selectionConfigErrorEffect = _v10.b;
 	var _v12 = function () {
-		var _v13 = A2($author$project$SelectedValueEncoding$stringToValueStrings, selectedValueEncoding, flags.bE);
+		var _v13 = A3($author$project$SelectedValueEncoding$stringToValueStrings, selectionConfig, selectedValueEncoding, flags.bE);
 		if (!_v13.$) {
 			var values = _v13.a;
 			return _Utils_Tuple2(values, $author$project$MuchSelect$NoEffect);
@@ -14156,7 +14162,7 @@ var $author$project$MuchSelect$update = F2(
 								}),
 							$author$project$MuchSelect$NoEffect);
 					case 'selected-value':
-						var _v43 = A2($author$project$SelectedValueEncoding$stringToValueStrings, model.h, newAttributeValue);
+						var _v43 = A3($author$project$SelectedValueEncoding$stringToValueStrings, model.a, model.h, newAttributeValue);
 						if (!_v43.$) {
 							var selectedValueStrings = _v43.a;
 							if (A2($author$project$OptionList$selectedOptionValuesAreEqual, selectedValueStrings, model.b)) {

--- a/run-pty.json
+++ b/run-pty.json
@@ -3,6 +3,8 @@
     "title": "Build much-select for development",
     "command": [
       "watchexec",
+      "--project-origin",
+      ".",
       "-w",
       "src",
       "--",
@@ -32,6 +34,8 @@
     "title": "Build HTML for demo/sandbox site",
     "command": [
       "watchexec",
+      "--project-origin",
+      ".",
       "-w",
       "site",
       "-w",
@@ -61,6 +65,8 @@
     "title": "Elm tests",
     "command": [
       "watchexec",
+      "--project-origin",
+      ".",
       "-w",
       "src",
       "-w",
@@ -82,6 +88,8 @@
     "title": "Build much-select for production",
     "command": [
       "watchexec",
+      "--project-origin",
+      ".",
       "-w",
       "src",
       "--",

--- a/src/MuchSelect.elm
+++ b/src/MuchSelect.elm
@@ -1611,7 +1611,7 @@ update msg model =
                     )
 
                 "selected-value" ->
-                    case SelectedValueEncoding.stringToValueStrings model.selectedValueEncoding newAttributeValue of
+                    case SelectedValueEncoding.stringToValueStrings model.selectionConfig model.selectedValueEncoding newAttributeValue of
                         Ok selectedValueStrings ->
                             if OptionList.selectedOptionValuesAreEqual selectedValueStrings model.options then
                                 ( model, NoEffect )
@@ -3395,7 +3395,7 @@ init flags =
                 |> Result.withDefault SelectedValueEncoding.defaultSelectedValueEncoding
 
         ( initialValues, initialValueErrEffect ) =
-            case SelectedValueEncoding.stringToValueStrings selectedValueEncoding flags.selectedValue of
+            case SelectedValueEncoding.stringToValueStrings selectionConfig selectedValueEncoding flags.selectedValue of
                 Ok values ->
                     ( values, NoEffect )
 

--- a/src/SelectedValueEncoding.elm
+++ b/src/SelectedValueEncoding.elm
@@ -5,7 +5,7 @@ import Json.Encode
 import Option exposing (Option)
 import OptionList exposing (OptionList)
 import Ports exposing (valueDecoder, valuesDecoder)
-import SelectionMode exposing (SelectionMode)
+import SelectionMode exposing (SelectionConfig(..), SelectionMode)
 import Url exposing (percentDecode, percentEncode)
 
 
@@ -59,8 +59,8 @@ toString selectedValueEncoding =
             "json"
 
 
-stringToValueStrings : SelectedValueEncoding -> String -> Result String (List String)
-stringToValueStrings selectedValueEncoding valuesString =
+stringToValueStrings : SelectionConfig -> SelectedValueEncoding -> String -> Result String (List String)
+stringToValueStrings config selectedValueEncoding valuesString =
     if valuesString == "" && selectedValueEncoding == CommaSeperated then
         Ok []
 
@@ -70,7 +70,12 @@ stringToValueStrings selectedValueEncoding valuesString =
     else
         case selectedValueEncoding of
             CommaSeperated ->
-                Ok (String.split "," valuesString)
+                case config of
+                    SingleSelectConfig _ _ _ ->
+                        Ok [ valuesString ]
+
+                    MultiSelectConfig _ _ _ ->
+                        Ok (String.split "," valuesString)
 
             JsonEncoded ->
                 percentDecode valuesString


### PR DESCRIPTION
Addresses: [GG-327](https://dripcom.atlassian.net/browse/GG-327)

Partial fix for commas in much select options. The issue comes up because we are using comma separated encoding for the selected value in most places. We get the selected value by splitting on `,`.

This updates comma separated encoding to skip spitting on `,` for single selects. A single select should only have one selected value, so there is no need to split in that case.

A more general fix would probably require switching to JSON encoding everywhere.

[GG-327]: https://dripcom.atlassian.net/browse/GG-327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ