### PR TITLE
Adding elm-format to our npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "chai-dom": "^1.11.0",
         "cypress": "^13.3.1",
         "elm-esm": "^1.1.4",
+        "elm-format": "^0.8.7",
         "elm-review": "^2.10.3",
         "elm-test": "0.19.1-revision12",
         "elm-tooling": "^1.15.0",
@@ -68,6 +69,71 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@avh4/elm-format-darwin-arm64": {
+      "version": "0.8.8-1",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-darwin-arm64/-/elm-format-darwin-arm64-0.8.8-1.tgz",
+      "integrity": "sha512-VDu3CRajhB/Sax+CEU4PhIzErBZv8vVxbk9Sk8seUHa1ngfICa3Ejoq3PhnoOFKYF1v1sSxNOC2RnUzvd/9bUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@avh4/elm-format-darwin-x64": {
+      "version": "0.8.8-1",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-darwin-x64/-/elm-format-darwin-x64-0.8.8-1.tgz",
+      "integrity": "sha512-9NAzi3HUBSHEIx3Nje+a6wFcv6RDKv2PO0OUNcV/XlS4Sou3r89xsYAVAXS8mi4+CKTdscyfSSkgGd8qiCCxAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@avh4/elm-format-linux-arm64": {
+      "version": "0.8.8-1",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-linux-arm64/-/elm-format-linux-arm64-0.8.8-1.tgz",
+      "integrity": "sha512-VNuXYphgxtnk7Gw+VBgWBeA9k8wKSo9r/O2F7udgurokYLO8S+RGhLHgD9mb6Yecv/veWz4v9n/O0IggH/BOCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@avh4/elm-format-linux-x64": {
+      "version": "0.8.8-1",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-linux-x64/-/elm-format-linux-x64-0.8.8-1.tgz",
+      "integrity": "sha512-IvtmUTDw/V5mBeglLgtQMzWZPc0QvmqUmoJ+vipxYii3DJ/1KV2drtpvlLuFdBlFrehUivtrh4HhOTsdGXxyXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@avh4/elm-format-win32-x64": {
+      "version": "0.8.8-1",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-win32-x64/-/elm-format-win32-x64-0.8.8-1.tgz",
+      "integrity": "sha512-qGYZM2oJFSVQ80Tayk1v15ba7PWCU3B89EkA3Fy4YQasvtA+UrYYR5Bv7MRF4kn6Zp7oSDk4FhknURFsZWZ7kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@babel/code-frame": {
       "version": "7.22.13",
@@ -3789,6 +3855,23 @@
       },
       "bin": {
         "elm-esm": "src/run.js"
+      }
+    },
+    "node_modules/elm-format": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/elm-format/-/elm-format-0.8.8.tgz",
+      "integrity": "sha512-OJYUtVnepuy8UZdnL5OCjSxUY5+dIGP2NdWTB6icxVVOOH0b8MpJIijTPsGW+ztnv9yzSoTK0dhCuVDh+AGhNQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "elm-format": "bin/elm-format"
+      },
+      "optionalDependencies": {
+        "@avh4/elm-format-darwin-arm64": "0.8.8-1",
+        "@avh4/elm-format-darwin-x64": "0.8.8-1",
+        "@avh4/elm-format-linux-arm64": "0.8.8-1",
+        "@avh4/elm-format-linux-x64": "0.8.8-1",
+        "@avh4/elm-format-win32-x64": "0.8.8-1"
       }
     },
     "node_modules/elm-review": {
@@ -10081,6 +10164,41 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
     },
+    "@avh4/elm-format-darwin-arm64": {
+      "version": "0.8.8-1",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-darwin-arm64/-/elm-format-darwin-arm64-0.8.8-1.tgz",
+      "integrity": "sha512-VDu3CRajhB/Sax+CEU4PhIzErBZv8vVxbk9Sk8seUHa1ngfICa3Ejoq3PhnoOFKYF1v1sSxNOC2RnUzvd/9bUw==",
+      "dev": true,
+      "optional": true
+    },
+    "@avh4/elm-format-darwin-x64": {
+      "version": "0.8.8-1",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-darwin-x64/-/elm-format-darwin-x64-0.8.8-1.tgz",
+      "integrity": "sha512-9NAzi3HUBSHEIx3Nje+a6wFcv6RDKv2PO0OUNcV/XlS4Sou3r89xsYAVAXS8mi4+CKTdscyfSSkgGd8qiCCxAw==",
+      "dev": true,
+      "optional": true
+    },
+    "@avh4/elm-format-linux-arm64": {
+      "version": "0.8.8-1",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-linux-arm64/-/elm-format-linux-arm64-0.8.8-1.tgz",
+      "integrity": "sha512-VNuXYphgxtnk7Gw+VBgWBeA9k8wKSo9r/O2F7udgurokYLO8S+RGhLHgD9mb6Yecv/veWz4v9n/O0IggH/BOCQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@avh4/elm-format-linux-x64": {
+      "version": "0.8.8-1",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-linux-x64/-/elm-format-linux-x64-0.8.8-1.tgz",
+      "integrity": "sha512-IvtmUTDw/V5mBeglLgtQMzWZPc0QvmqUmoJ+vipxYii3DJ/1KV2drtpvlLuFdBlFrehUivtrh4HhOTsdGXxyXQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@avh4/elm-format-win32-x64": {
+      "version": "0.8.8-1",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-win32-x64/-/elm-format-win32-x64-0.8.8-1.tgz",
+      "integrity": "sha512-qGYZM2oJFSVQ80Tayk1v15ba7PWCU3B89EkA3Fy4YQasvtA+UrYYR5Bv7MRF4kn6Zp7oSDk4FhknURFsZWZ7kg==",
+      "dev": true,
+      "optional": true
+    },
     "@babel/code-frame": {
       "version": "7.22.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
@@ -12847,6 +12965,19 @@
       "dev": true,
       "requires": {
         "which": "^2.0.2"
+      }
+    },
+    "elm-format": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/elm-format/-/elm-format-0.8.8.tgz",
+      "integrity": "sha512-OJYUtVnepuy8UZdnL5OCjSxUY5+dIGP2NdWTB6icxVVOOH0b8MpJIijTPsGW+ztnv9yzSoTK0dhCuVDh+AGhNQ==",
+      "dev": true,
+      "requires": {
+        "@avh4/elm-format-darwin-arm64": "0.8.8-1",
+        "@avh4/elm-format-darwin-x64": "0.8.8-1",
+        "@avh4/elm-format-linux-arm64": "0.8.8-1",
+        "@avh4/elm-format-linux-x64": "0.8.8-1",
+        "@avh4/elm-format-win32-x64": "0.8.8-1"
       }
     },
     "elm-review": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "chai-dom": "^1.11.0",
     "cypress": "^13.3.1",
     "elm-esm": "^1.1.4",
+    "elm-format": "^0.8.7",
     "elm-review": "^2.10.3",
     "elm-test": "0.19.1-revision12",
     "elm-tooling": "^1.15.0",


### PR DESCRIPTION
`elm-format` is already referenced in the code, we just didn't include it in our dev dependencies.