### PR TITLE
Fixing uniqueness performance

### DIFF
--- a/dist/much-select-elm-debug.js
+++ b/dist/much-select-elm-debug.js
@@ -12802,52 +12802,67 @@ var $author$project$OptionList$removeEmptyOptions = function (optionList) {
 		A2($elm$core$Basics$composeR, $author$project$Option$isEmpty, $elm$core$Basics$not),
 		optionList);
 };
-var $elm$core$List$member = F2(
-	function (x, xs) {
-		return A2(
-			$elm$core$List$any,
-			function (a) {
-				return _Utils_eq(a, x);
-			},
-			xs);
+var $elm$core$Set$Set_elm_builtin = function (a) {
+	return {$: 'Set_elm_builtin', a: a};
+};
+var $elm$core$Set$empty = $elm$core$Set$Set_elm_builtin($elm$core$Dict$empty);
+var $elm$core$Set$insert = F2(
+	function (key, _v0) {
+		var dict = _v0.a;
+		return $elm$core$Set$Set_elm_builtin(
+			A3($elm$core$Dict$insert, key, _Utils_Tuple0, dict));
 	});
-var $elm_community$list_extra$List$Extra$uniqueHelp = F4(
-	function (f, existing, remaining, accumulator) {
-		uniqueHelp:
+var $elm$core$Dict$member = F2(
+	function (key, dict) {
+		var _v0 = A2($elm$core$Dict$get, key, dict);
+		if (_v0.$ === 'Just') {
+			return true;
+		} else {
+			return false;
+		}
+	});
+var $elm$core$Set$member = F2(
+	function (key, _v0) {
+		var dict = _v0.a;
+		return A2($elm$core$Dict$member, key, dict);
+	});
+var $author$project$OptionList$fasterUniqueByHelper = F4(
+	function (_function, remainingList, acc, seen) {
+		fasterUniqueByHelper:
 		while (true) {
-			if (!remaining.b) {
-				return $elm$core$List$reverse(accumulator);
+			if (!remainingList.b) {
+				return $elm$core$List$reverse(acc);
 			} else {
-				var first = remaining.a;
-				var rest = remaining.b;
-				var computedFirst = f(first);
-				if (A2($elm$core$List$member, computedFirst, existing)) {
-					var $temp$f = f,
-						$temp$existing = existing,
-						$temp$remaining = rest,
-						$temp$accumulator = accumulator;
-					f = $temp$f;
-					existing = $temp$existing;
-					remaining = $temp$remaining;
-					accumulator = $temp$accumulator;
-					continue uniqueHelp;
+				var x = remainingList.a;
+				var xs = remainingList.b;
+				var key = _function(x);
+				if (A2($elm$core$Set$member, key, seen)) {
+					var $temp$function = _function,
+						$temp$remainingList = xs,
+						$temp$acc = acc,
+						$temp$seen = seen;
+					_function = $temp$function;
+					remainingList = $temp$remainingList;
+					acc = $temp$acc;
+					seen = $temp$seen;
+					continue fasterUniqueByHelper;
 				} else {
-					var $temp$f = f,
-						$temp$existing = A2($elm$core$List$cons, computedFirst, existing),
-						$temp$remaining = rest,
-						$temp$accumulator = A2($elm$core$List$cons, first, accumulator);
-					f = $temp$f;
-					existing = $temp$existing;
-					remaining = $temp$remaining;
-					accumulator = $temp$accumulator;
-					continue uniqueHelp;
+					var $temp$function = _function,
+						$temp$remainingList = xs,
+						$temp$acc = A2($elm$core$List$cons, x, acc),
+						$temp$seen = A2($elm$core$Set$insert, key, seen);
+					_function = $temp$function;
+					remainingList = $temp$remainingList;
+					acc = $temp$acc;
+					seen = $temp$seen;
+					continue fasterUniqueByHelper;
 				}
 			}
 		}
 	});
-var $elm_community$list_extra$List$Extra$uniqueBy = F2(
-	function (f, list) {
-		return A4($elm_community$list_extra$List$Extra$uniqueHelp, f, _List_Nil, list, _List_Nil);
+var $author$project$OptionList$fasterUniqueBy = F2(
+	function (_function, list) {
+		return A4($author$project$OptionList$fasterUniqueByHelper, _function, list, _List_Nil, $elm$core$Set$empty);
 	});
 var $author$project$OptionList$uniqueBy = F2(
 	function (_function, optionList) {
@@ -12855,15 +12870,15 @@ var $author$project$OptionList$uniqueBy = F2(
 			case 'FancyOptionList':
 				var options = optionList.a;
 				return $author$project$OptionList$FancyOptionList(
-					A2($elm_community$list_extra$List$Extra$uniqueBy, _function, options));
+					A2($author$project$OptionList$fasterUniqueBy, _function, options));
 			case 'DatalistOptionList':
 				var options = optionList.a;
 				return $author$project$OptionList$DatalistOptionList(
-					A2($elm_community$list_extra$List$Extra$uniqueBy, _function, options));
+					A2($author$project$OptionList$fasterUniqueBy, _function, options));
 			default:
 				var options = optionList.a;
 				return $author$project$OptionList$SlottedOptionList(
-					A2($elm_community$list_extra$List$Extra$uniqueBy, _function, options));
+					A2($author$project$OptionList$fasterUniqueBy, _function, options));
 		}
 	});
 var $author$project$OptionList$organizeNewDatalistOptions = function (optionList) {

--- a/dist/much-select-elm.js
+++ b/dist/much-select-elm.js
@@ -7444,52 +7444,206 @@ var $author$project$OptionList$removeEmptyOptions = function (optionList) {
 		A2($elm$core$Basics$composeR, $author$project$Option$isEmpty, $elm$core$Basics$not),
 		optionList);
 };
-var $elm$core$List$member = F2(
-	function (x, xs) {
-		return A2(
-			$elm$core$List$any,
-			function (a) {
-				return _Utils_eq(a, x);
-			},
-			xs);
+var $elm$core$Set$Set_elm_builtin = $elm$core$Basics$identity;
+var $elm$core$Dict$RBEmpty_elm_builtin = {$: -2};
+var $elm$core$Dict$empty = $elm$core$Dict$RBEmpty_elm_builtin;
+var $elm$core$Set$empty = $elm$core$Dict$empty;
+var $elm$core$Dict$Black = 1;
+var $elm$core$Dict$RBNode_elm_builtin = F5(
+	function (a, b, c, d, e) {
+		return {$: -1, a: a, b: b, c: c, d: d, e: e};
 	});
-var $elm_community$list_extra$List$Extra$uniqueHelp = F4(
-	function (f, existing, remaining, accumulator) {
-		uniqueHelp:
-		while (true) {
-			if (!remaining.b) {
-				return $elm$core$List$reverse(accumulator);
+var $elm$core$Dict$Red = 0;
+var $elm$core$Dict$balance = F5(
+	function (color, key, value, left, right) {
+		if ((right.$ === -1) && (!right.a)) {
+			var _v1 = right.a;
+			var rK = right.b;
+			var rV = right.c;
+			var rLeft = right.d;
+			var rRight = right.e;
+			if ((left.$ === -1) && (!left.a)) {
+				var _v3 = left.a;
+				var lK = left.b;
+				var lV = left.c;
+				var lLeft = left.d;
+				var lRight = left.e;
+				return A5(
+					$elm$core$Dict$RBNode_elm_builtin,
+					0,
+					key,
+					value,
+					A5($elm$core$Dict$RBNode_elm_builtin, 1, lK, lV, lLeft, lRight),
+					A5($elm$core$Dict$RBNode_elm_builtin, 1, rK, rV, rLeft, rRight));
 			} else {
-				var first = remaining.a;
-				var rest = remaining.b;
-				var computedFirst = f(first);
-				if (A2($elm$core$List$member, computedFirst, existing)) {
-					var $temp$f = f,
-						$temp$existing = existing,
-						$temp$remaining = rest,
-						$temp$accumulator = accumulator;
-					f = $temp$f;
-					existing = $temp$existing;
-					remaining = $temp$remaining;
-					accumulator = $temp$accumulator;
-					continue uniqueHelp;
-				} else {
-					var $temp$f = f,
-						$temp$existing = A2($elm$core$List$cons, computedFirst, existing),
-						$temp$remaining = rest,
-						$temp$accumulator = A2($elm$core$List$cons, first, accumulator);
-					f = $temp$f;
-					existing = $temp$existing;
-					remaining = $temp$remaining;
-					accumulator = $temp$accumulator;
-					continue uniqueHelp;
+				return A5(
+					$elm$core$Dict$RBNode_elm_builtin,
+					color,
+					rK,
+					rV,
+					A5($elm$core$Dict$RBNode_elm_builtin, 0, key, value, left, rLeft),
+					rRight);
+			}
+		} else {
+			if ((((left.$ === -1) && (!left.a)) && (left.d.$ === -1)) && (!left.d.a)) {
+				var _v5 = left.a;
+				var lK = left.b;
+				var lV = left.c;
+				var _v6 = left.d;
+				var _v7 = _v6.a;
+				var llK = _v6.b;
+				var llV = _v6.c;
+				var llLeft = _v6.d;
+				var llRight = _v6.e;
+				var lRight = left.e;
+				return A5(
+					$elm$core$Dict$RBNode_elm_builtin,
+					0,
+					lK,
+					lV,
+					A5($elm$core$Dict$RBNode_elm_builtin, 1, llK, llV, llLeft, llRight),
+					A5($elm$core$Dict$RBNode_elm_builtin, 1, key, value, lRight, right));
+			} else {
+				return A5($elm$core$Dict$RBNode_elm_builtin, color, key, value, left, right);
+			}
+		}
+	});
+var $elm$core$Basics$compare = _Utils_compare;
+var $elm$core$Dict$insertHelp = F3(
+	function (key, value, dict) {
+		if (dict.$ === -2) {
+			return A5($elm$core$Dict$RBNode_elm_builtin, 0, key, value, $elm$core$Dict$RBEmpty_elm_builtin, $elm$core$Dict$RBEmpty_elm_builtin);
+		} else {
+			var nColor = dict.a;
+			var nKey = dict.b;
+			var nValue = dict.c;
+			var nLeft = dict.d;
+			var nRight = dict.e;
+			var _v1 = A2($elm$core$Basics$compare, key, nKey);
+			switch (_v1) {
+				case 0:
+					return A5(
+						$elm$core$Dict$balance,
+						nColor,
+						nKey,
+						nValue,
+						A3($elm$core$Dict$insertHelp, key, value, nLeft),
+						nRight);
+				case 1:
+					return A5($elm$core$Dict$RBNode_elm_builtin, nColor, nKey, value, nLeft, nRight);
+				default:
+					return A5(
+						$elm$core$Dict$balance,
+						nColor,
+						nKey,
+						nValue,
+						nLeft,
+						A3($elm$core$Dict$insertHelp, key, value, nRight));
+			}
+		}
+	});
+var $elm$core$Dict$insert = F3(
+	function (key, value, dict) {
+		var _v0 = A3($elm$core$Dict$insertHelp, key, value, dict);
+		if ((_v0.$ === -1) && (!_v0.a)) {
+			var _v1 = _v0.a;
+			var k = _v0.b;
+			var v = _v0.c;
+			var l = _v0.d;
+			var r = _v0.e;
+			return A5($elm$core$Dict$RBNode_elm_builtin, 1, k, v, l, r);
+		} else {
+			var x = _v0;
+			return x;
+		}
+	});
+var $elm$core$Set$insert = F2(
+	function (key, _v0) {
+		var dict = _v0;
+		return A3($elm$core$Dict$insert, key, 0, dict);
+	});
+var $elm$core$Dict$get = F2(
+	function (targetKey, dict) {
+		get:
+		while (true) {
+			if (dict.$ === -2) {
+				return $elm$core$Maybe$Nothing;
+			} else {
+				var key = dict.b;
+				var value = dict.c;
+				var left = dict.d;
+				var right = dict.e;
+				var _v1 = A2($elm$core$Basics$compare, targetKey, key);
+				switch (_v1) {
+					case 0:
+						var $temp$targetKey = targetKey,
+							$temp$dict = left;
+						targetKey = $temp$targetKey;
+						dict = $temp$dict;
+						continue get;
+					case 1:
+						return $elm$core$Maybe$Just(value);
+					default:
+						var $temp$targetKey = targetKey,
+							$temp$dict = right;
+						targetKey = $temp$targetKey;
+						dict = $temp$dict;
+						continue get;
 				}
 			}
 		}
 	});
-var $elm_community$list_extra$List$Extra$uniqueBy = F2(
-	function (f, list) {
-		return A4($elm_community$list_extra$List$Extra$uniqueHelp, f, _List_Nil, list, _List_Nil);
+var $elm$core$Dict$member = F2(
+	function (key, dict) {
+		var _v0 = A2($elm$core$Dict$get, key, dict);
+		if (!_v0.$) {
+			return true;
+		} else {
+			return false;
+		}
+	});
+var $elm$core$Set$member = F2(
+	function (key, _v0) {
+		var dict = _v0;
+		return A2($elm$core$Dict$member, key, dict);
+	});
+var $author$project$OptionList$fasterUniqueByHelper = F4(
+	function (_function, remainingList, acc, seen) {
+		fasterUniqueByHelper:
+		while (true) {
+			if (!remainingList.b) {
+				return $elm$core$List$reverse(acc);
+			} else {
+				var x = remainingList.a;
+				var xs = remainingList.b;
+				var key = _function(x);
+				if (A2($elm$core$Set$member, key, seen)) {
+					var $temp$function = _function,
+						$temp$remainingList = xs,
+						$temp$acc = acc,
+						$temp$seen = seen;
+					_function = $temp$function;
+					remainingList = $temp$remainingList;
+					acc = $temp$acc;
+					seen = $temp$seen;
+					continue fasterUniqueByHelper;
+				} else {
+					var $temp$function = _function,
+						$temp$remainingList = xs,
+						$temp$acc = A2($elm$core$List$cons, x, acc),
+						$temp$seen = A2($elm$core$Set$insert, key, seen);
+					_function = $temp$function;
+					remainingList = $temp$remainingList;
+					acc = $temp$acc;
+					seen = $temp$seen;
+					continue fasterUniqueByHelper;
+				}
+			}
+		}
+	});
+var $author$project$OptionList$fasterUniqueBy = F2(
+	function (_function, list) {
+		return A4($author$project$OptionList$fasterUniqueByHelper, _function, list, _List_Nil, $elm$core$Set$empty);
 	});
 var $author$project$OptionList$uniqueBy = F2(
 	function (_function, optionList) {
@@ -7497,15 +7651,15 @@ var $author$project$OptionList$uniqueBy = F2(
 			case 0:
 				var options = optionList.a;
 				return $author$project$OptionList$FancyOptionList(
-					A2($elm_community$list_extra$List$Extra$uniqueBy, _function, options));
+					A2($author$project$OptionList$fasterUniqueBy, _function, options));
 			case 1:
 				var options = optionList.a;
 				return $author$project$OptionList$DatalistOptionList(
-					A2($elm_community$list_extra$List$Extra$uniqueBy, _function, options));
+					A2($author$project$OptionList$fasterUniqueBy, _function, options));
 			default:
 				var options = optionList.a;
 				return $author$project$OptionList$SlottedOptionList(
-					A2($elm_community$list_extra$List$Extra$uniqueBy, _function, options));
+					A2($author$project$OptionList$fasterUniqueBy, _function, options));
 		}
 	});
 var $author$project$OptionList$organizeNewDatalistOptions = function (optionList) {


### PR DESCRIPTION
`List.Extra.uniqueBy` apparently is not very performant with very long lists. The issue here is that the way it works is by iterating over every item in the list `O(n)` and then for each one, it adds it to a `List` of "known" values. If that value already exists in the known values (`List.member`) then it will NOT carry it over to the final list. `List.member`, however, is a `O(n)` operation itself, so that leads to this essentially being `O(n^2)`. This seems to tip over around 10-20k rows where it becomes noticeably slow. I was observing upwards of 40 seconds on my mac for lists of 100k.

My alternative to this implementation is pretty simple, in fact it's the exact same algorithm, just swapping out the `List` of known values and `List.member` check with a `Set` of known values and a `Set.member` check. 

Without going into the Javascript implementation of core Elm, I'm guessing that Set membership is probably  `O(n log n)`.

For comparison, here's the old implementation:

## List.Extra.uniqueBy

```elm
-- https://github.com/elm-community/list-extra/blob/8.7.0/src/List/Extra.elm#L448
uniqueBy : (a -> b) -> List a -> List a
uniqueBy f list =
    uniqueHelp f [] list []

-- https://github.com/elm-community/list-extra/blob/8.7.0/src/List/Extra.elm#L474 
uniqueHelp : (a -> b) -> List b -> List a -> List a -> List a
uniqueHelp f existing remaining accumulator =
    case remaining of
        [] ->
            List.reverse accumulator

        first :: rest ->
            let
                computedFirst =
                    f first
            in
            if List.member computedFirst existing then
                uniqueHelp f existing rest accumulator

            else
                uniqueHelp f (computedFirst :: existing) rest (first :: accumulator)
```

Note that they essentially follow the same algorithm aside from the presence check being a `List.member`